### PR TITLE
1.10.0: mood prompt after 18:00

### DIFF
--- a/My Year/Views/MoodTrackingCalendar.swift
+++ b/My Year/Views/MoodTrackingCalendar.swift
@@ -51,7 +51,9 @@ struct MoodTrackingCalendar: View {
   private func checkTodayValuation() {
     guard isMoodTrackingEnabled else { return }
     let today = Date()
-    let todayKey = DateInRegion(today, region: .current).toFormat("yyyy-MM-dd")
+    let localToday = DateInRegion(today, region: .current)
+    guard localToday.hour >= 18 else { return }
+    let todayKey = localToday.toFormat("yyyy-MM-dd")
     guard lastMoodPromptDayKey != todayKey else { return }
     if store.getValuation(for: today) == nil {
       lastMoodPromptDayKey = todayKey


### PR DESCRIPTION
Delay the in-app mood tracking prompt: only trigger after 18:00 local time (keeps once-per-day guard and only prompts when today's valuation is missing).