### PR TITLE
Phase 3A: Smart Timing - Streak Protection Reminders

### DIFF
--- a/My Year/Managers/Notifications.swift
+++ b/My Year/Managers/Notifications.swift
@@ -246,6 +246,94 @@ private struct StreakStats {
   let weeklyCompletionRate: Double
 }
 
+// MARK: - Streak Protection
+
+/// Schedules a streak protection reminder for late in the day
+/// - Parameters:
+///   - calendar: The calendar to protect
+///   - store: Calendar store for streak calculation
+public func scheduleStreakProtectionReminder(
+  for calendar: CustomCalendar,
+  store: CustomCalendarStore
+) {
+  // Only schedule if enabled and reminders are on
+  guard calendar.streakProtectionEnabled,
+        calendar.recurringReminderEnabled else {
+    return
+  }
+  
+  // Calculate current streak
+  let stats = calculateStreakStats(for: calendar, store: store)
+  
+  // Only protect significant streaks
+  guard stats.currentStreak >= calendar.streakProtectionThreshold else {
+    return
+  }
+  
+  // Schedule notification for 9 PM today
+  let now = Date()
+  let calendar_swift = Calendar.current
+  guard let ninePM = calendar_swift.date(bySettingHour: 21, minute: 0, second: 0, of: now) else {
+    return
+  }
+  
+  // Only schedule if 9 PM is in the future
+  guard ninePM > now else {
+    return
+  }
+  
+  let notificationId = "\(calendar.id.uuidString)-streak-protection"
+  let content = UNMutableNotificationContent()
+  
+  // Urgent, streak-focused copy
+  switch calendar.notificationPrivacyMode {
+  case .full:
+    content.title = String(localized: "🔥 Don't break your \(stats.currentStreak)-day streak!")
+    content.body = String(localized: "Quick! Log \(calendar.name) before midnight")
+    
+  case .generic:
+    content.title = String(localized: "🔥 Streak at risk!")
+    content.body = String(localized: "Don't forget to log your habit today")
+    
+  case .hidden:
+    content.badge = NSNumber(value: 1)
+    content.title = ""
+    content.body = ""
+  }
+  
+  content.sound = .default
+  content.categoryIdentifier = NotificationAction.categoryIdentifier
+  content.userInfo = [
+    "calendarId": calendar.id.uuidString,
+    "calendarName": calendar.name,
+    "isStreakProtection": true
+  ]
+  
+  // Schedule for 9 PM today (one-time, not recurring)
+  let triggerDate = calendar_swift.dateComponents(
+    [.year, .month, .day, .hour, .minute],
+    from: ninePM
+  )
+  let trigger = UNCalendarNotificationTrigger(
+    dateMatching: triggerDate,
+    repeats: false
+  )
+  
+  let request = UNNotificationRequest(
+    identifier: notificationId,
+    content: content,
+    trigger: trigger
+  )
+  
+  UNUserNotificationCenter.current().add(request) { error in
+    if let error = error {
+      print("❌ Failed to schedule streak protection: \(error)")
+    } else {
+      print("🛡️ Scheduled streak protection for \(calendar.name) at 9 PM (\(stats.currentStreak)-day streak)")
+    }
+  }
+}
+
 // MARK: - Notification Scheduling
 
 /// Schedules notifications for a calendar with proper error handling and permission checks
@@ -260,11 +348,18 @@ public func scheduleNotifications(
 ) {
   let notificationId = calendar.id.uuidString
   
-  // Remove all existing notifications for this calendar (primary + additional)
+  // Schedule streak protection if store available
+  if let store = store {
+    scheduleStreakProtectionReminder(for: calendar, store: store)
+  }
+  
+  // Remove all existing notifications for this calendar (primary + additional + streak protection)
   var allNotificationIds = [notificationId]
   for (index, _) in calendar.additionalReminderTimes.enumerated() {
     allNotificationIds.append("\(notificationId)-\(index)")
   }
+  allNotificationIds.append("\(notificationId)-streak-protection")
+  
   UNUserNotificationCenter.current().removePendingNotificationRequests(
     withIdentifiers: allNotificationIds
   )

--- a/My Year/Managers/Notifications.swift
+++ b/My Year/Managers/Notifications.swift
@@ -348,11 +348,6 @@ public func scheduleNotifications(
 ) {
   let notificationId = calendar.id.uuidString
   
-  // Schedule streak protection if store available
-  if let store = store {
-    scheduleStreakProtectionReminder(for: calendar, store: store)
-  }
-  
   // Remove all existing notifications for this calendar (primary + additional + streak protection)
   var allNotificationIds = [notificationId]
   for (index, _) in calendar.additionalReminderTimes.enumerated() {
@@ -369,6 +364,11 @@ public func scheduleNotifications(
         calendar.recurringReminderEnabled else {
     completion(.success(()))
     return
+  }
+  
+  // Schedule streak protection if store available
+  if let store = store {
+    scheduleStreakProtectionReminder(for: calendar, store: store)
   }
   
   // Collect all reminder times (primary + additional)

--- a/SharedModels/Sources/SharedModels/SharedModels.swift
+++ b/SharedModels/Sources/SharedModels/SharedModels.swift
@@ -202,6 +202,8 @@ public struct CustomCalendar: Codable, Identifiable {
   public var notificationPrivacyMode: NotificationPrivacyMode = .full  // Privacy mode for notifications
   public var suppressWhenCompleted: Bool = true  // Don't send notification if entry already completed
   public var additionalReminderTimes: [ReminderTime] = []  // Additional reminder times (beyond primary reminderHour/reminderMinute)
+  public var streakProtectionEnabled: Bool = true  // Send late-day reminder if streak at risk
+  public var streakProtectionThreshold: Int = 5  // Minimum streak length to trigger protection (default: 5 days)
   public var entries: [String: CalendarEntry]  // Date string -> Entry
 
   public init(
@@ -215,7 +217,9 @@ public struct CustomCalendar: Codable, Identifiable {
     reminderTimeZone: String? = nil,
     notificationPrivacyMode: NotificationPrivacyMode = .full,
     suppressWhenCompleted: Bool = true,
-    additionalReminderTimes: [ReminderTime] = []
+    additionalReminderTimes: [ReminderTime] = [],
+    streakProtectionEnabled: Bool = true,
+    streakProtectionThreshold: Int = 5
   ) {
     self.id = id
     self.name = name
@@ -232,6 +236,8 @@ public struct CustomCalendar: Codable, Identifiable {
     self.notificationPrivacyMode = notificationPrivacyMode
     self.suppressWhenCompleted = suppressWhenCompleted
     self.additionalReminderTimes = additionalReminderTimes
+    self.streakProtectionEnabled = streakProtectionEnabled
+    self.streakProtectionThreshold = streakProtectionThreshold
     if let time = reminderTime {
       let calendar = Calendar.current
       self.reminderHour = calendar.component(.hour, from: time)
@@ -256,7 +262,9 @@ public struct CustomCalendar: Codable, Identifiable {
     reminderTimeZone: String? = nil,
     notificationPrivacyMode: NotificationPrivacyMode = .full,
     suppressWhenCompleted: Bool = true,
-    additionalReminderTimes: [ReminderTime] = []
+    additionalReminderTimes: [ReminderTime] = [],
+    streakProtectionEnabled: Bool = true,
+    streakProtectionThreshold: Int = 5
   ) throws {
     // Validate hour and minute ranges
     if let hour = reminderHour, let minute = reminderMinute {
@@ -284,6 +292,8 @@ public struct CustomCalendar: Codable, Identifiable {
     self.notificationPrivacyMode = notificationPrivacyMode
     self.suppressWhenCompleted = suppressWhenCompleted
     self.additionalReminderTimes = additionalReminderTimes
+    self.streakProtectionEnabled = streakProtectionEnabled
+    self.streakProtectionThreshold = streakProtectionThreshold
     self.entries = entries
   }
 }

--- a/SharedModels/Sources/SharedModels/SwiftDataModels.swift
+++ b/SharedModels/Sources/SharedModels/SwiftDataModels.swift
@@ -20,6 +20,8 @@ public final class HabitCalendarEntity {
   public var notificationPrivacyModeRawValue: String = NotificationPrivacyMode.full.rawValue
   public var suppressWhenCompleted: Bool = true
   public var additionalReminderTimesJSON: String? // JSON-encoded [ReminderTime]
+  public var streakProtectionEnabled: Bool = true
+  public var streakProtectionThreshold: Int = 5
   public var order: Int = 0
 
   public init(
@@ -39,6 +41,8 @@ public final class HabitCalendarEntity {
     notificationPrivacyModeRawValue: String = NotificationPrivacyMode.full.rawValue,
     suppressWhenCompleted: Bool = true,
     additionalReminderTimesJSON: String? = nil,
+    streakProtectionEnabled: Bool = true,
+    streakProtectionThreshold: Int = 5,
     order: Int = 0
   ) {
     self.id = id
@@ -57,6 +61,8 @@ public final class HabitCalendarEntity {
     self.notificationPrivacyModeRawValue = notificationPrivacyModeRawValue
     self.suppressWhenCompleted = suppressWhenCompleted
     self.additionalReminderTimesJSON = additionalReminderTimesJSON
+    self.streakProtectionEnabled = streakProtectionEnabled
+    self.streakProtectionThreshold = streakProtectionThreshold
     self.order = order
   }
 }
@@ -217,7 +223,9 @@ extension HabitCalendarEntity {
       reminderTimeZone: reminderTimeZone,
       notificationPrivacyMode: privacyMode,
       suppressWhenCompleted: suppressWhenCompleted,
-      additionalReminderTimes: additionalTimes
+      additionalReminderTimes: additionalTimes,
+      streakProtectionEnabled: streakProtectionEnabled,
+      streakProtectionThreshold: streakProtectionThreshold
     ) {
       return calendar
     }
@@ -239,7 +247,9 @@ extension HabitCalendarEntity {
       reminderTimeZone: reminderTimeZone,
       notificationPrivacyMode: privacyMode,
       suppressWhenCompleted: suppressWhenCompleted,
-      additionalReminderTimes: additionalTimes
+      additionalReminderTimes: additionalTimes,
+      streakProtectionEnabled: streakProtectionEnabled,
+      streakProtectionThreshold: streakProtectionThreshold
     )
   }
 
@@ -259,6 +269,8 @@ extension HabitCalendarEntity {
     notificationPrivacyModeRawValue = model.notificationPrivacyMode.rawValue
     suppressWhenCompleted = model.suppressWhenCompleted
     additionalReminderTimesJSON = Self.encodeAdditionalReminderTimes(model.additionalReminderTimes)
+    streakProtectionEnabled = model.streakProtectionEnabled
+    streakProtectionThreshold = model.streakProtectionThreshold
     order = model.order
   }
 
@@ -280,6 +292,8 @@ extension HabitCalendarEntity {
       notificationPrivacyModeRawValue: model.notificationPrivacyMode.rawValue,
       suppressWhenCompleted: model.suppressWhenCompleted,
       additionalReminderTimesJSON: encodeAdditionalReminderTimes(model.additionalReminderTimes),
+      streakProtectionEnabled: model.streakProtectionEnabled,
+      streakProtectionThreshold: model.streakProtectionThreshold,
       order: model.order
     )
   }


### PR DESCRIPTION
## Phase 3A - Smart Timing: Streak Protection

This PR implements the first smart timing feature: automatic streak protection reminders.

### 🛡️ Feature: Streak Protection Reminders

Automatically sends an urgent late-day reminder (9 PM) if user has a significant streak at risk.

**Problem:** User on 15-day streak, hasn't logged by 9 PM → loses streak  
**Solution:** Extra "don't break your streak!" notification

### 🔥 How It Works

**Automatic Protection:**
- Checks at schedule time if calendar has active streak
- If streak ≥ threshold (default: 5 days), schedules 9 PM notification
- One-time notification for today only (not recurring)
- Only fires if entry NOT completed (respects suppressWhenCompleted)

**Smart Copy:**

**Full Mode:**
- 🔥 "Don't break your 12-day streak!"
- "Quick! Log Running before midnight"

**Generic Mode:**
- 🔥 "Streak at risk!"
- "Don't forget to log your habit today"

### ⚙️ Configuration

New calendar properties:
- `streakProtectionEnabled: Bool` - Toggle feature (default: true)
- `streakProtectionThreshold: Int` - Min streak to protect (default: 5 days)

### 📊 Use Cases

**Example 1: Long streak protection**
- User: 15-day Running streak
- Usually logs in morning, today forgot
- 9 PM: "🔥 Don't break your 15-day streak!"

**Example 2: Building habit**
- User: 3-day Reading streak (< 5 day threshold)
- Result: No streak protection (not significant enough)

**Example 3: Already logged**
- User: 10-day Meditation streak
- Logged at 7 AM
- 9 PM: Notification suppressed (already completed)

### 🔧 Technical Implementation

**Schedule Logic:**
1. Called during regular notification scheduling
2. Calculates current streak using existing calculateStreakStats()
3. Only schedules if streak ≥ threshold
4. Schedules for 9 PM using UNCalendarNotificationTrigger
5. Non-repeating (one-shot)

**Notification ID:** `<calendar-id>-streak-protection`

**Integration:**
- Uses existing suppression logic
- Removed with other calendar notifications
- Works with all privacy modes

### ✅ Testing
- [x] Streak ≥ threshold schedules protection
- [x] Streak < threshold skips protection
- [x] Entry completed → notification suppressed
- [x] Privacy modes work correctly
- [x] Removed with calendar notifications
- [x] One-time only (not recurring)

### 🚀 Future Enhancements

Next phase could add:
- UI toggle for streak protection
- Configurable protection time (not just 9 PM)
- Usage analytics (when user typically logs)
- Smart suggestions ("Move reminder to 7 AM?")

### 📦 Files Changed
- `My Year/Managers/Notifications.swift` - Streak protection scheduling
- `SharedModels/.../SharedModels.swift` - New properties
- `SharedModels/.../SwiftDataModels.swift` - Persistence

---

**Depends on:** PR #44 (Phase 3 Enhancements)  
**Base branch:** 1.10.0-notification-phase3-enhancements

🔥 No more lost streaks!