### PR TITLE
fix: default timeline for new users

### DIFF
--- a/My Year/My_YearApp.swift
+++ b/My Year/My_YearApp.swift
@@ -171,7 +171,7 @@ struct My_YearApp: App {
         updateTimelinePreferencePresentation()
       }) {
         OnboardingView {
-          onboarding.markAsSeen()
+          completeOnboarding()
         }
       }
       .fullScreenCover(isPresented: $isTimelinePreferenceSheetPresented) {
@@ -204,9 +204,19 @@ struct My_YearApp: App {
       get: { !onboarding.hasSeenOnboarding },
       set: { isPresented in
         guard !isPresented else { return }
-        onboarding.markAsSeen()
+        completeOnboarding()
       }
     )
+  }
+
+  private func completeOnboarding() {
+    let isNewUser = !onboarding.hasSeenOnboarding
+    if isNewUser {
+      TimelinePreferenceStore.setDefaultModeIfNeeded()
+      TimelinePreferenceManager.shared.refresh()
+    }
+
+    onboarding.markAsSeen()
   }
 
   private func updateTimelinePreferencePresentation() {

--- a/My YearTests/TimelinePreferenceStoreTests.swift
+++ b/My YearTests/TimelinePreferenceStoreTests.swift
@@ -26,6 +26,18 @@ struct TimelinePreferenceStoreTests {
         #expect(TimelinePreferenceStore.mode(defaults: defaults) == .calendarYear)
     }
 
+    @Test func defaultModeWriteIsOnlyForMissingPreference() {
+        let defaults = makeDefaults()
+        defer { tearDownDefaults(defaults) }
+
+        TimelinePreferenceStore.setDefaultModeIfNeeded(defaults: defaults)
+        #expect(TimelinePreferenceStore.storedMode(defaults: defaults) == .your365)
+
+        TimelinePreferenceStore.setMode(.calendarYear, defaults: defaults)
+        TimelinePreferenceStore.setDefaultModeIfNeeded(defaults: defaults)
+        #expect(TimelinePreferenceStore.storedMode(defaults: defaults) == .calendarYear)
+    }
+
     @Test func rawValueParsingDefaultsToYour365ForMissingOrInvalidValues() {
         #expect(TimelinePreferenceStore.mode(rawValue: nil) == .your365)
         #expect(TimelinePreferenceStore.mode(rawValue: "") == .your365)

--- a/SharedModels/Sources/SharedModels/TimelinePreferenceStore.swift
+++ b/SharedModels/Sources/SharedModels/TimelinePreferenceStore.swift
@@ -32,6 +32,11 @@ public enum TimelinePreferenceStore {
         defaults.set(mode.rawValue, forKey: timelineModeKey)
     }
 
+    public static func setDefaultModeIfNeeded(defaults: UserDefaults = appGroupDefaults) {
+        guard !hasStoredMode(defaults: defaults) else { return }
+        setMode(.your365, defaults: defaults)
+    }
+
     public static func hasStoredMode(defaults: UserDefaults = appGroupDefaults) -> Bool {
         storedMode(defaults: defaults) != nil
     }


### PR DESCRIPTION
## Summary
- set Your 365 as the stored default when a new user completes onboarding
- keep the timeline preference picker for existing users without a stored preference
- add coverage for writing the default only when the preference is missing

## Tests
- xcodebuild test -scheme "My Year" -only-testing:"My YearTests/TimelinePreferenceStoreTests"