### PR TITLE
fix: cap share preview card size

### DIFF
--- a/My Year/Views/Share/CalendarShareSheet.swift
+++ b/My Year/Views/Share/CalendarShareSheet.swift
@@ -81,6 +81,8 @@ struct CalendarShareSheet: View {
 
     private let sharePointSize = CGSize(width: 360, height: 450)
     private let shareScale: CGFloat = 3
+    private let previewHorizontalPadding: CGFloat = 32
+    private let previewVerticalPadding: CGFloat = 16
 
     var body: some View {
         NavigationStack {
@@ -134,21 +136,36 @@ struct CalendarShareSheet: View {
     }
 
     private var cardPager: some View {
-        TabView(selection: $selectedTemplate) {
-            ForEach(availableShareTemplates(for: calendar, today: Date())) { template in
-                cardView(for: template)
-                    .aspectRatio(4 / 5, contentMode: .fit)
-                    .shadow(color: .black.opacity(0.25), radius: 20, x: 0, y: 10)
-                    .padding(.horizontal, 32)
-                    .padding(.vertical, 16)
-                    .tag(template)
-                    .onTapGesture {
-                        guard template.isPremiumOnly, !isPremium else { return }
-                        isPaywallPresented = true
-                    }
+        GeometryReader { proxy in
+            let cardSize = previewCardSize(for: proxy.size)
+
+            TabView(selection: $selectedTemplate) {
+                ForEach(availableShareTemplates(for: calendar, today: Date())) { template in
+                    cardView(for: template)
+                        .frame(width: cardSize.width, height: cardSize.height)
+                        .shadow(color: .black.opacity(0.25), radius: 20, x: 0, y: 10)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .tag(template)
+                        .onTapGesture {
+                            guard template.isPremiumOnly, !isPremium else { return }
+                            isPaywallPresented = true
+                        }
+                }
             }
+            .tabViewStyle(.page(indexDisplayMode: .never))
         }
-        .tabViewStyle(.page(indexDisplayMode: .never))
+        .frame(height: sharePointSize.height)
+        .padding(.horizontal, previewHorizontalPadding)
+        .padding(.vertical, previewVerticalPadding)
+    }
+
+    private func previewCardSize(for availableSize: CGSize) -> CGSize {
+        let availableWidth = max(0, availableSize.width)
+        let cardWidth = min(sharePointSize.width, availableWidth)
+        return CGSize(
+            width: cardWidth,
+            height: cardWidth * sharePointSize.height / sharePointSize.width
+        )
     }
 
     private var actionButtons: some View {

--- a/My Year/Views/Share/MilestoneCelebrationSheet.swift
+++ b/My Year/Views/Share/MilestoneCelebrationSheet.swift
@@ -26,6 +26,8 @@ struct MilestoneCelebrationSheet: View {
     private let stopAction = MilestoneCelebrationStopAction()
     private let sharePointSize = CGSize(width: 360, height: 450)
     private let shareScale: CGFloat = 3
+    private let previewHorizontalPadding: CGFloat = 32
+    private let previewVerticalPadding: CGFloat = 16
 
     init(
         calendar: CustomCalendar,
@@ -104,27 +106,42 @@ struct MilestoneCelebrationSheet: View {
     }
 
     private var cardView: some View {
-        StreakMilestoneCardView(
-            calendar: calendar,
-            milestone: milestone,
-            currentStreak: currentStreak,
-            dates: dates,
-            kind: kind,
-            glareOffset: CGSize(
-                width: motion.roll * 3,
-                height: -motion.pitch * 3
+        GeometryReader { proxy in
+            let cardSize = previewCardSize(for: proxy.size)
+
+            StreakMilestoneCardView(
+                calendar: calendar,
+                milestone: milestone,
+                currentStreak: currentStreak,
+                dates: dates,
+                kind: kind,
+                glareOffset: CGSize(
+                    width: motion.roll * 3,
+                    height: -motion.pitch * 3
+                )
             )
+            .frame(width: cardSize.width, height: cardSize.height)
+            .shadow(color: .black.opacity(0.25), radius: 20, x: 0, y: 10)
+            .rotation3DEffect(.degrees(motion.pitch), axis: (x: 1, y: 0, z: 0), perspective: 0.8)
+            .rotation3DEffect(.degrees(motion.roll), axis: (x: 0, y: 1, z: 0), perspective: 0.8)
+            .scaleEffect(isCardVisible ? 1 : 0.88)
+            .opacity(isCardVisible ? 1 : 0)
+            .offset(y: isCardVisible ? 0 : 28)
+            .blur(radius: isCardVisible ? 0 : 10)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(height: sharePointSize.height)
+        .padding(.horizontal, previewHorizontalPadding)
+        .padding(.vertical, previewVerticalPadding)
+    }
+
+    private func previewCardSize(for availableSize: CGSize) -> CGSize {
+        let availableWidth = max(0, availableSize.width)
+        let cardWidth = min(sharePointSize.width, availableWidth)
+        return CGSize(
+            width: cardWidth,
+            height: cardWidth * sharePointSize.height / sharePointSize.width
         )
-        .aspectRatio(4 / 5, contentMode: .fit)
-        .shadow(color: .black.opacity(0.25), radius: 20, x: 0, y: 10)
-        .rotation3DEffect(.degrees(motion.pitch), axis: (x: 1, y: 0, z: 0), perspective: 0.8)
-        .rotation3DEffect(.degrees(motion.roll), axis: (x: 0, y: 1, z: 0), perspective: 0.8)
-        .scaleEffect(isCardVisible ? 1 : 0.88)
-        .opacity(isCardVisible ? 1 : 0)
-        .offset(y: isCardVisible ? 0 : 28)
-        .blur(radius: isCardVisible ? 0 : 10)
-        .padding(.horizontal, 32)
-        .padding(.vertical, 16)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- cap share card previews to the exported image point size on wider layouts
- keep previews responsive by shrinking below 360pt width
- leave rendered/saved image output unchanged

## Verification
- xcodebuild -scheme "My Year" build