### PR TITLE
Add check-in button flow

### DIFF
--- a/My Year/Views/CustomCalendarView.swift
+++ b/My Year/Views/CustomCalendarView.swift
@@ -187,12 +187,27 @@ struct CustomCalendarView: View {
     Task {
       await hapticFeedback()
     }
+    presentEntryEditSheet(calendar: activeCalendar, date: date)
+  }
+
+  private func handleCheckInButtonTap(calendar: CustomCalendar, date: Date?) {
+    guard let date else { return }
+    guard !date.isInFuture else { return }
+    guard !calendar.isAppleHealthConnected else { return }
+
+    Task {
+      await hapticFeedback()
+    }
+    presentEntryEditSheet(calendar: calendar, date: date)
+  }
+
+  private func presentEntryEditSheet(calendar: CustomCalendar, date: Date) {
     isEntryEditSheetPresented = true
     router.showScreen(
       .sheetConfig(config: shortSheetConfig)
     ) { _ in
       DayEntryEditSheet(
-        calendar: activeCalendar,
+        calendar: calendar,
         date: date,
         store: store,
         onSave: {
@@ -200,7 +215,7 @@ struct CustomCalendarView: View {
         },
         onDismiss: {
           isEntryEditSheetPresented = false
-          evaluateMilestonesIfNeeded(calendarId: activeCalendar.id)
+          evaluateMilestonesIfNeeded(calendarId: calendar.id)
         }
       )
     }
@@ -595,6 +610,26 @@ struct CustomCalendarView: View {
 
         let currentPeriodLogCount: Int? = renderSnapshot.currentPeriodReferenceDate.map {
           entry(for: activeCalendar, date: $0)?.count ?? 0
+        }
+        let checkInDate = renderSnapshot.currentPeriodReferenceDate
+        let hasCurrentPeriodLog = (currentPeriodLogCount ?? 0) > 0
+
+        if !activeCalendar.isAppleHealthConnected, checkInDate != nil {
+          Button {
+            handleCheckInButtonTap(calendar: activeCalendar, date: checkInDate)
+          } label: {
+            HStack(spacing: 8) {
+              Image(systemName: hasCurrentPeriodLog ? "square.and.pencil" : "checkmark")
+              Text(hasCurrentPeriodLog ? "Edit Check-in" : "Check in")
+            }
+            .frame(maxWidth: .infinity)
+            .fontWeight(.bold)
+            .padding()
+          }
+          .sameLevelBorder()
+          .foregroundStyle(.textSecondary)
+          .padding(.horizontal)
+          .padding(.top, 4)
         }
 
         if let bundle = statsBundle {

--- a/My Year/Views/Entry/DayEntryEditSheet.swift
+++ b/My Year/Views/Entry/DayEntryEditSheet.swift
@@ -39,7 +39,7 @@ struct DayEntryEditSheet: View {
             return
         }
         let existingEntry = store.getEntry(calendarId: calendar.id, date: date)
-        let newEntry = CalendarEntry(date: date, count: entryCount, completed: entryCompleted)
+        let newEntry = normalizedEntry()
         store.addEntry(calendarId: calendar.id, entry: newEntry)
         CalendarAnalyticsTracker.shared.trackEntryMutation(
             calendar: calendar,
@@ -49,6 +49,17 @@ struct DayEntryEditSheet: View {
         )
         onSave?()
         dismiss()
+    }
+
+    private func normalizedEntry() -> CalendarEntry {
+        switch calendar.trackingType {
+        case .binary:
+            return CalendarEntry(date: date, count: entryCompleted ? 1 : 0, completed: entryCompleted)
+        case .counter:
+            return CalendarEntry(date: date, count: entryCount, completed: entryCount > 0)
+        case .multipleDaily:
+            return CalendarEntry(date: date, count: entryCount, completed: entryCount >= calendar.dailyTarget)
+        }
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- Add a calendar detail check-in/edit check-in button for the current period
- Route day taps and the check-in button through a shared entry sheet presenter
- Normalize edited entries by tracking type before saving

## Validation
- git diff --check
- swiftlint lint --quiet "My Year/Views/CustomCalendarView.swift" "My Year/Views/Entry/DayEntryEditSheet.swift" *(fails on existing CustomCalendarView size/style violations)*