### PR TITLE
Harden legacy migration safety

### DIFF
--- a/SharedModels/Sources/SharedModels/DataBackupService.swift
+++ b/SharedModels/Sources/SharedModels/DataBackupService.swift
@@ -139,6 +139,10 @@ public final class DataBackupService {
             .sorted { $0.createdAt > $1.createdAt } ?? []
     }
 
+    func isBackupValid(id: UUID) -> Bool {
+        availableBackups().contains(where: { $0.id == id })
+    }
+
     public func restoreBackup(id: UUID) throws {
         guard let metadata = availableBackups().first(where: { $0.id == id }) else {
             throw DataBackupError.backupNotFound

--- a/SharedModels/Sources/SharedModels/LegacyDataMigration.swift
+++ b/SharedModels/Sources/SharedModels/LegacyDataMigration.swift
@@ -16,16 +16,20 @@ enum LegacyPersistenceKeys {
     static let trackingStartedAtBackupKey = "swiftDataTrackingStartedAtBackupV1"
     static let legacyCalendarRepairFlagKey = "swiftDataLegacyCalendarRepairV1Complete"
     static let legacyCalendarRepairV2FlagKey = "swiftDataLegacyCalendarRepairV2Complete"
+    static let migrationBackupFlagKey = "DataBackup.beforeMigrationCreated"
 }
 
 @available(iOS 17.0, macOS 14.0, *)
 enum LegacyDataMigrator {
+    private static let migrationLock = NSLock()
+
     private struct TrackingStartedAtBackup: Codable {
         let createdAt: Date
         let valuesByCalendarId: [String: Date]
     }
 
     static func migrateIfNeeded(container: ModelContainer = SwiftDataManager.container) {
+        guard shouldRunMigration(in: Bundle.main.bundleURL) else { return }
         guard let defaults = UserDefaults(suiteName: LegacyPersistenceKeys.appGroupId) else {
             return
         }
@@ -33,7 +37,14 @@ enum LegacyDataMigrator {
         migrateIfNeeded(container: container, defaults: defaults)
     }
 
-    static func migrateIfNeeded(container: ModelContainer, defaults: UserDefaults) {
+    static func migrateIfNeeded(
+        container: ModelContainer,
+        defaults: UserDefaults,
+        backupDirectoryURL: URL? = DataBackupService.defaultDirectoryURL()
+    ) {
+        migrationLock.lock()
+        defer { migrationLock.unlock() }
+
         // Only migrate legacy data once.
         let alreadyMigrated = defaults.bool(forKey: LegacyPersistenceKeys.migrationFlagKey)
         var legacyMigrationSucceeded = alreadyMigrated
@@ -43,7 +54,11 @@ enum LegacyDataMigrator {
         }
 
         guard legacyMigrationSucceeded else { return }
-        guard createMigrationBackupIfNeeded(container: container, defaults: defaults) else { return }
+        guard createMigrationBackupIfNeeded(
+            container: container,
+            defaults: defaults,
+            directoryURL: backupDirectoryURL
+        ) else { return }
 
         let dayKeyMigrationSucceeded = migrateDayKeysIfNeeded(defaults: defaults, container: container)
 
@@ -55,8 +70,15 @@ enum LegacyDataMigrator {
         }
     }
 
-    private static func createMigrationBackupIfNeeded(container: ModelContainer, defaults: UserDefaults) -> Bool {
-        let backupKey = "DataBackup.beforeMigrationCreated"
+    static func shouldRunMigration(in bundleURL: URL) -> Bool {
+        bundleURL.pathExtension != "appex"
+    }
+
+    private static func createMigrationBackupIfNeeded(
+        container: ModelContainer,
+        defaults: UserDefaults,
+        directoryURL: URL?
+    ) -> Bool {
         let migrationFlags = [
             LegacyPersistenceKeys.dayKeyMigrationFlagKey,
             LegacyPersistenceKeys.trackingStartedAtBackfillMigrationFlagKey,
@@ -66,14 +88,18 @@ enum LegacyDataMigrator {
         ]
         let hasPendingMigration = migrationFlags.contains { !defaults.bool(forKey: $0) }
         guard hasPendingMigration else { return true }
-        guard !defaults.bool(forKey: backupKey) else { return true }
+        let backupService = DataBackupService(
+            container: container,
+            directoryURL: directoryURL,
+            defaults: defaults
+        )
         do {
-            try DataBackupService(
-                container: container,
-                defaults: defaults
-            )
-            .createProtectiveBackup(reason: .beforeMigration)
-            defaults.set(true, forKey: backupKey)
+            let backup = try backupService.createProtectiveBackup(reason: .beforeMigration)
+            guard backupService.isBackupValid(id: backup.id) else {
+                NSLog("Pre-migration data backup failed validation")
+                return false
+            }
+            defaults.set(true, forKey: LegacyPersistenceKeys.migrationBackupFlagKey)
             return true
         } catch {
             NSLog("Failed to create pre-migration data backup: \(error)")

--- a/SharedModels/Tests/SharedModelsTests/AppleHealthCalendarModelTests.swift
+++ b/SharedModels/Tests/SharedModelsTests/AppleHealthCalendarModelTests.swift
@@ -150,8 +150,8 @@ struct AppleHealthCalendarModelTests {
   @MainActor
   @Test func migrationRepairV2RestoresActiveMetadataFromLegacyPayload() throws {
     let container = try makeContainer()
-    let (defaultsSuiteName, defaults) = makeDefaults()
-    defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+    let (defaultsSuiteName, defaults, backupDirectory) = makeDefaults()
+    defer { removeDefaults(defaults, suiteName: defaultsSuiteName, backupDirectory: backupDirectory) }
 
     let id = UUID()
     let legacyCalendar = CustomCalendar(
@@ -191,7 +191,11 @@ struct AppleHealthCalendarModelTests {
     )
     try context.save()
 
-    LegacyDataMigrator.migrateIfNeeded(container: container, defaults: defaults)
+    LegacyDataMigrator.migrateIfNeeded(
+      container: container,
+      defaults: defaults,
+      backupDirectoryURL: backupDirectory
+    )
 
     let calendars = try context.fetch(FetchDescriptor<HabitCalendarEntity>())
     let repairedCalendar = try #require(calendars.first)
@@ -203,8 +207,8 @@ struct AppleHealthCalendarModelTests {
   @MainActor
   @Test func migrationRepairsMissingSwiftDataEntriesFromLegacyPayload() throws {
     let container = try makeContainer()
-    let (defaultsSuiteName, defaults) = makeDefaults()
-    defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+    let (defaultsSuiteName, defaults, backupDirectory) = makeDefaults()
+    defer { removeDefaults(defaults, suiteName: defaultsSuiteName, backupDirectory: backupDirectory) }
 
     let calendar = CustomCalendar(
       name: "No energy drinks",
@@ -229,7 +233,11 @@ struct AppleHealthCalendarModelTests {
     context.insert(HabitCalendarEntity.make(from: calendar))
     try context.save()
 
-    LegacyDataMigrator.migrateIfNeeded(container: container, defaults: defaults)
+    LegacyDataMigrator.migrateIfNeeded(
+      container: container,
+      defaults: defaults,
+      backupDirectoryURL: backupDirectory
+    )
 
     let entries = try context.fetch(FetchDescriptor<CalendarEntryEntity>())
 
@@ -241,8 +249,8 @@ struct AppleHealthCalendarModelTests {
   @MainActor
   @Test func migrationRepairsMissingSwiftDataCalendarsFromLegacyPayload() throws {
     let container = try makeContainer()
-    let (defaultsSuiteName, defaults) = makeDefaults()
-    defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+    let (defaultsSuiteName, defaults, backupDirectory) = makeDefaults()
+    defer { removeDefaults(defaults, suiteName: defaultsSuiteName, backupDirectory: backupDirectory) }
 
     let calendar = CustomCalendar(
       name: "Reading",
@@ -263,7 +271,11 @@ struct AppleHealthCalendarModelTests {
     defaults.set(true, forKey: LegacyPersistenceKeys.migrationFlagKey)
     defaults.set(true, forKey: LegacyPersistenceKeys.dayKeyMigrationFlagKey)
 
-    LegacyDataMigrator.migrateIfNeeded(container: container, defaults: defaults)
+    LegacyDataMigrator.migrateIfNeeded(
+      container: container,
+      defaults: defaults,
+      backupDirectoryURL: backupDirectory
+    )
 
     let context = ModelContext(container)
     let calendars = try context.fetch(FetchDescriptor<HabitCalendarEntity>())
@@ -477,11 +489,18 @@ struct AppleHealthCalendarModelTests {
     return calendar.date(from: DateComponents(year: year, month: month, day: day))!
   }
 
-  private func makeDefaults() -> (suiteName: String, defaults: UserDefaults) {
+  private func makeDefaults() -> (suiteName: String, defaults: UserDefaults, backupDirectory: URL) {
     let suiteName = "SharedModelsTests.\(UUID().uuidString)"
     let defaults = UserDefaults(suiteName: suiteName)!
     defaults.removePersistentDomain(forName: suiteName)
-    return (suiteName, defaults)
+    let backupDirectory = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    return (suiteName, defaults, backupDirectory)
+  }
+
+  private func removeDefaults(_ defaults: UserDefaults, suiteName: String, backupDirectory: URL) {
+    defaults.removePersistentDomain(forName: suiteName)
+    try? FileManager.default.removeItem(at: backupDirectory)
   }
 
   @MainActor

--- a/SharedModels/Tests/SharedModelsTests/DataBackupServiceTests.swift
+++ b/SharedModels/Tests/SharedModelsTests/DataBackupServiceTests.swift
@@ -116,6 +116,7 @@ struct DataBackupServiceTests {
     try json.write(to: url, atomically: true, encoding: .utf8)
 
     #expect(harness.service.availableBackups().isEmpty)
+    #expect(!harness.service.isBackupValid(id: backup.id))
   }
 
   @MainActor

--- a/SharedModels/Tests/SharedModelsTests/LegacyDataMigrationConcurrencyTests.swift
+++ b/SharedModels/Tests/SharedModelsTests/LegacyDataMigrationConcurrencyTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import SharedModels
+
+struct LegacyDataMigrationConcurrencyTests {
+  @Test func appExtensionsDoNotRunMigration() {
+    #expect(!LegacyDataMigrator.shouldRunMigration(in: URL(fileURLWithPath: "/App/Widget.appex")))
+    #expect(LegacyDataMigrator.shouldRunMigration(in: URL(fileURLWithPath: "/App/Yearlit.app")))
+  }
+
+  @Test func concurrentMigrationImportsLegacyDataOnce() throws {
+    let suiteName = "LegacyDataMigrationConcurrencyTests.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    let container = try makeContainer()
+    let calendar = CustomCalendar(
+      name: "Legacy",
+      color: "qs-emerald",
+      trackingType: .binary,
+      trackingStartedAt: Date(),
+      dailyTarget: 1
+    )
+    defaults.set(try JSONEncoder().encode([calendar]), forKey: LegacyPersistenceKeys.calendarsKey)
+    markFollowUpMigrationsComplete(in: defaults)
+
+    DispatchQueue.concurrentPerform(iterations: 8) { _ in
+      LegacyDataMigrator.migrateIfNeeded(container: container, defaults: defaults)
+    }
+
+    let context = ModelContext(container)
+    let count = try context.fetchCount(FetchDescriptor<HabitCalendarEntity>())
+    #expect(count == 1)
+    #expect(defaults.bool(forKey: LegacyPersistenceKeys.migrationFlagKey))
+  }
+
+  @Test func pendingMigrationCreatesFreshBackupDespiteExistingFlag() throws {
+    let suiteName = "LegacyDataMigrationBackupTests.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    let container = try makeContainer()
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let service = DataBackupService(container: container, directoryURL: directory, defaults: defaults)
+    _ = try service.createProtectiveBackup(reason: .beforeMigration)
+    let context = ModelContext(container)
+    context.insert(HabitCalendarEntity(
+      name: "New data",
+      color: "qs-blue",
+      trackingTypeRawValue: TrackingType.binary.rawValue,
+      dailyTarget: 1
+    ))
+    try context.save()
+    defaults.set(true, forKey: LegacyPersistenceKeys.migrationFlagKey)
+    defaults.set(true, forKey: LegacyPersistenceKeys.migrationBackupFlagKey)
+
+    LegacyDataMigrator.migrateIfNeeded(
+      container: container,
+      defaults: defaults,
+      backupDirectoryURL: directory
+    )
+
+    let migrationBackups = service.availableBackups().filter { $0.reason == .beforeMigration }
+    #expect(migrationBackups.count == 2)
+    #expect(Set(migrationBackups.map(\.fingerprint)).count == 2)
+  }
+
+  private func makeContainer() throws -> ModelContainer {
+    try ModelContainer(
+      for: HabitCalendarEntity.self,
+      CalendarEntryEntity.self,
+      DayValuationEntity.self,
+      HabitStackEntity.self,
+      HabitStackStepEntity.self,
+      configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+    )
+  }
+
+  private func markFollowUpMigrationsComplete(in defaults: UserDefaults) {
+    defaults.set(true, forKey: LegacyPersistenceKeys.dayKeyMigrationFlagKey)
+    defaults.set(true, forKey: LegacyPersistenceKeys.trackingStartedAtBackfillMigrationFlagKey)
+    defaults.set(true, forKey: LegacyPersistenceKeys.trackingStartedAtRepairMigrationFlagKey)
+    defaults.set(true, forKey: LegacyPersistenceKeys.legacyCalendarRepairFlagKey)
+    defaults.set(true, forKey: LegacyPersistenceKeys.legacyCalendarRepairV2FlagKey)
+  }
+}

--- a/SharedModels/Tests/SharedModelsTests/PersistenceContractTests.swift
+++ b/SharedModels/Tests/SharedModelsTests/PersistenceContractTests.swift
@@ -1,0 +1,220 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import SharedModels
+
+struct PersistenceContractTests {
+  @MainActor
+  @Test func backupRestorePreservesCompletePersistenceContract() throws {
+    let fixture = try Fixture()
+    try fixture.seed()
+    let backup = try fixture.service.createProtectiveBackup(reason: .beforeBulkChange)
+
+    try fixture.deleteAll()
+    try fixture.service.restoreBackup(id: backup.id)
+
+    let context = ModelContext(fixture.container)
+    let calendar = try #require(context.fetch(FetchDescriptor<HabitCalendarEntity>()).first)
+    let entry = try #require(context.fetch(FetchDescriptor<CalendarEntryEntity>()).first)
+    let valuation = try #require(context.fetch(FetchDescriptor<DayValuationEntity>()).first)
+    let stack = try #require(context.fetch(FetchDescriptor<HabitStackEntity>()).first)
+    let step = try #require(context.fetch(FetchDescriptor<HabitStackStepEntity>()).first)
+
+    fixture.expectCalendar(calendar)
+    fixture.expectEntry(entry)
+    fixture.expectValuation(valuation)
+    fixture.expectStack(stack)
+    fixture.expectStep(step)
+  }
+
+  @MainActor
+  private final class Fixture {
+    let calendarId: UUID
+    let stackId: UUID
+    let stepId: UUID
+    let trackingStartedAt: Date
+    let entryDate: Date
+    let valuationDate: Date
+    let createdAt: Date
+    let updatedAt: Date
+    let container: ModelContainer
+    let service: DataBackupService
+
+    var entryDayKey: String { DayKeyFormatter.shared.string(from: entryDate) }
+    var valuationDayKey: String { DayKeyFormatter.shared.string(from: valuationDate) }
+
+    init() throws {
+      calendarId = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+      stackId = try #require(UUID(uuidString: "11111111-2222-3333-4444-555555555555"))
+      stepId = try #require(UUID(uuidString: "66666666-7777-8888-9999-AAAAAAAAAAAA"))
+      trackingStartedAt = try #require(Self.makeDate(year: 2025, month: 12, day: 29))
+      entryDate = try #require(Self.makeDate(year: 2026, month: 1, day: 5))
+      valuationDate = try #require(Self.makeDate(year: 2026, month: 1, day: 6))
+      createdAt = try #require(Self.makeDate(year: 2025, month: 12, day: 1))
+      updatedAt = try #require(Self.makeDate(year: 2026, month: 1, day: 7))
+      container = try ModelContainer(
+        for: HabitCalendarEntity.self,
+        CalendarEntryEntity.self,
+        DayValuationEntity.self,
+        HabitStackEntity.self,
+        HabitStackStepEntity.self,
+        configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+      )
+      let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+      service = DataBackupService(container: container, directoryURL: directory)
+    }
+
+    func seed() throws {
+      let context = ModelContext(container)
+      context.autosaveEnabled = false
+      let calendar = try CustomCalendar(
+        id: calendarId,
+        name: "Complete",
+        color: "qs-purple",
+        cadence: .weekly,
+        trackingType: .multipleDaily,
+        trackingStartedAt: trackingStartedAt,
+        dailyTarget: 7,
+        entries: [entryDayKey: CalendarEntry(date: entryDate, count: 5, completed: false)],
+        isArchived: true,
+        recurringReminderEnabled: true,
+        reminderHour: 21,
+        reminderMinute: 15,
+        reminderWeekday: 6,
+        order: 4,
+        unit: .pages,
+        defaultRecordValue: 3,
+        currencySymbol: "€",
+        reminderTimeZone: "Europe/Rome",
+        notificationPrivacyMode: .generic,
+        suppressWhenCompleted: false,
+        additionalReminderTimes: [ReminderTime(hour: 8, minute: 30)],
+        streakProtectionEnabled: false,
+        streakProtectionThreshold: 12,
+        source: .manual
+      )
+      context.insert(HabitCalendarEntity.make(from: calendar))
+      context.insert(CalendarEntryEntity(
+        compositeKey: CalendarEntryEntity.makeCompositeKey(calendarId: calendarId, dayKey: entryDayKey),
+        calendarId: calendarId,
+        dayKey: entryDayKey,
+        date: entryDate,
+        count: 5,
+        completed: false
+      ))
+      context.insert(DayValuationEntity(
+        dayKey: valuationDayKey,
+        timestamp: valuationDate,
+        moodRawValue: DayMood.excellent.rawValue,
+        note: "Kept note"
+      ))
+      context.insert(HabitStackEntity(
+        id: stackId,
+        name: "Evening",
+        prompt: "Wind down",
+        scheduledHour: 22,
+        scheduledMinute: 30,
+        order: 2,
+        createdAt: createdAt,
+        updatedAt: updatedAt
+      ))
+      context.insert(HabitStackStepEntity(
+        id: stepId,
+        stackId: stackId,
+        title: "Read",
+        detail: "Ten pages",
+        linkedCalendarId: calendarId,
+        order: 1,
+        createdAt: createdAt,
+        updatedAt: updatedAt
+      ))
+      try context.save()
+    }
+
+    func expectCalendar(_ calendar: HabitCalendarEntity) {
+      #expect(calendar.id == calendarId)
+      #expect(calendar.name == "Complete")
+      #expect(calendar.color == "qs-purple")
+      #expect(calendar.cadenceRawValue == CalendarCadence.weekly.rawValue)
+      #expect(calendar.trackingTypeRawValue == TrackingType.multipleDaily.rawValue)
+      #expect(calendar.trackingStartedAt == LocalDayCalendar.startOfDay(for: trackingStartedAt))
+      #expect(calendar.dailyTarget == 7)
+      #expect(calendar.unitRawValue == UnitOfMeasure.pages.rawValue)
+      #expect(calendar.defaultRecordValue == 3)
+      #expect(calendar.currencySymbol == "€")
+      #expect(calendar.isArchived)
+      #expect(calendar.recurringReminderEnabled)
+      #expect(calendar.reminderHour == 21)
+      #expect(calendar.reminderMinute == 15)
+      #expect(calendar.reminderWeekday == 6)
+      #expect(calendar.reminderTimeZone == "Europe/Rome")
+      #expect(calendar.notificationPrivacyModeRawValue == NotificationPrivacyMode.generic.rawValue)
+      #expect(!calendar.suppressWhenCompleted)
+      #expect(calendar.additionalReminderTimesJSON?.contains("8") == true)
+      #expect(!calendar.streakProtectionEnabled)
+      #expect(calendar.streakProtectionThreshold == 12)
+      #expect(calendar.sourceRawValue == CalendarSource.manual.rawValue)
+      #expect(calendar.order == 0)
+    }
+
+    func expectEntry(_ entry: CalendarEntryEntity) {
+      #expect(entry.compositeKey == CalendarEntryEntity.makeCompositeKey(
+        calendarId: calendarId,
+        dayKey: entryDayKey
+      ))
+      #expect(entry.calendarId == calendarId)
+      #expect(entry.dayKey == entryDayKey)
+      #expect(entry.date == entryDate)
+      #expect(entry.count == 5)
+      #expect(!entry.completed)
+    }
+
+    func expectValuation(_ valuation: DayValuationEntity) {
+      #expect(valuation.dayKey == valuationDayKey)
+      #expect(valuation.timestamp == LocalDayCalendar.startOfDay(for: valuationDate))
+      #expect(valuation.moodRawValue == DayMood.excellent.rawValue)
+      #expect(valuation.note == "Kept note")
+    }
+
+    func expectStack(_ stack: HabitStackEntity) {
+      #expect(stack.id == stackId)
+      #expect(stack.name == "Evening")
+      #expect(stack.prompt == "Wind down")
+      #expect(stack.scheduledHour == 22)
+      #expect(stack.scheduledMinute == 30)
+      #expect(stack.order == 2)
+      #expect(stack.createdAt == createdAt)
+      #expect(stack.updatedAt == updatedAt)
+    }
+
+    func expectStep(_ step: HabitStackStepEntity) {
+      #expect(step.id == stepId)
+      #expect(step.stackId == stackId)
+      #expect(step.title == "Read")
+      #expect(step.detail == "Ten pages")
+      #expect(step.linkedCalendarId == calendarId)
+      #expect(step.order == 0)
+      #expect(step.createdAt == createdAt)
+      #expect(step.updatedAt == updatedAt)
+    }
+
+    func deleteAll() throws {
+      let context = ModelContext(container)
+      for entity in try context.fetch(FetchDescriptor<HabitCalendarEntity>()) { context.delete(entity) }
+      for entity in try context.fetch(FetchDescriptor<CalendarEntryEntity>()) { context.delete(entity) }
+      for entity in try context.fetch(FetchDescriptor<DayValuationEntity>()) { context.delete(entity) }
+      for entity in try context.fetch(FetchDescriptor<HabitStackEntity>()) { context.delete(entity) }
+      for entity in try context.fetch(FetchDescriptor<HabitStackStepEntity>()) { context.delete(entity) }
+      try context.save()
+    }
+
+    private static func makeDate(year: Int, month: Int, day: Int) -> Date? {
+      var calendar = Calendar(identifier: .gregorian)
+      calendar.locale = Locale(identifier: "en_US_POSIX")
+      calendar.timeZone = .gmt
+      return calendar.date(from: DateComponents(year: year, month: month, day: day))
+    }
+  }
+}


### PR DESCRIPTION
Closes part of #130.

## Summary

- serialize legacy migration within the app process so duplicate callers cannot import the same payload multiple times
- make migration app-owned so widget extensions remain read-only and cannot race the app across processes
- create a fresh protective backup for every pending migration attempt
- read back and validate the exact new backup ID before migration proceeds
- keep migration flags pending when backup creation or validation fails
- add exhaustive backup/restore contract characterization for calendar, entry, valuation, stack, and linked-step data
- isolate migration tests from the real app-group backup directory

No SwiftData schema, property, identifier, store URL, app-group ID, CloudKit configuration, UserDefaults key value, backup schema, widget model, or deep-link contract changed.

## Tests and checks

- `swift test` — 23 tests passed
- Debug generic iOS Simulator build — passed
- signed Debug iPhone 17 Pro Max simulator build — passed
- `git diff --check` — passed
- SwiftLint — repository still has pre-existing baseline violations; new focused test files have no lint errors

## E2E evidence

- installed signed build on iPhone 17 Pro Max simulator
- cold-opened `sargon17.My-Year`
- verified the Yearlit What's New UI through accessibility snapshot
- captured simulator metrics: ~304 MB resident memory and 1.4% CPU while the sheet was visible
- simulator frame-health metrics unavailable by tool limitation
- startup round-trip sample was 13.0s but includes first install/runner overhead, so it is recorded as non-benchmark evidence only

## Review loop

Three strict review rounds completed. Fixed:

- process-local lock was insufficient while extensions could migrate
- Boolean backup flag could outlive the backup
- an old valid backup could predate newer user data
- backup write success did not prove the file could be decoded and fingerprint/count validated

Deferred from this PR:

- explicit non-destructive persistence bootstrap/recovery UI for app-group/container-open failure
- launch and rendering performance changes
- pre-existing Swift 6 concurrency warnings
- raw noncontiguous order integers; domain models intentionally normalize order while preserving semantic ordering, IDs, and content

## Assumptions

- migrations remain exceptional and app-owned
- every pending attempt must have a fresh, exact-ID validated backup
- this is the first focused PR in the larger performance/reliability epic
