### PR TITLE
Prevent destructive persistence startup fallback

### DIFF
--- a/HabitsWidget/HabitsWidget.swift
+++ b/HabitsWidget/HabitsWidget.swift
@@ -456,8 +456,6 @@ struct HabitQuickAddIntent: AppIntent {
   }
 
   func perform() async throws -> some IntentResult {
-    let store = await MainActor.run { CustomCalendarStore.shared }
-
     guard let calendarId = UUID(uuidString: calendarId) else {
       WidgetAnalyticsQueue.shared.enqueueQuickAddPerformed(properties: [
         "widget_kind": .string(WidgetAnalyticsKind.habits.rawValue),
@@ -468,8 +466,21 @@ struct HabitQuickAddIntent: AppIntent {
       return .result()
     }
 
-    let calendar = await MainActor.run {
-      CustomCalendarStore.fetchCalendarsSnapshot().first(where: { $0.id == calendarId })
+    guard let container = SwiftDataManager.availableContainer else {
+      WidgetAnalyticsQueue.shared.enqueueQuickAddPerformed(properties: [
+        "widget_kind": .string(WidgetAnalyticsKind.habits.rawValue),
+        "cadence": .string("unknown"),
+        "tracking_type": .string("unknown"),
+        "result": .string("persistence_unavailable")
+      ])
+      return .result()
+    }
+
+    let (store, calendar) = await MainActor.run {
+      let store = CustomCalendarStore(container: container)
+      let calendar = CustomCalendarStore.fetchCalendarsSnapshot(container: container)
+        .first(where: { $0.id == calendarId })
+      return (store, calendar)
     }
 
     guard let calendar else {

--- a/My Year/My_YearApp.swift
+++ b/My Year/My_YearApp.swift
@@ -48,6 +48,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     } else {
       // Handle action buttons (Log Now, Snooze)
       Task { @MainActor in
+        guard SwiftDataManager.isAvailable else { return }
         handleNotificationAction(response, store: CustomCalendarStore.shared)
       }
     }
@@ -62,6 +63,10 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
   ) {
     Task { @MainActor in
+      guard SwiftDataManager.isAvailable else {
+        completionHandler([.banner, .sound, .badge])
+        return
+      }
       let userInfo = notification.request.content.userInfo
       let snapshot = CustomCalendarStore.shared.snapshot
       if let calendarIdString = userInfo["calendarId"] as? String,
@@ -94,6 +99,7 @@ struct My_YearApp: App {
   @State private var isDataRecoveryPresented = false
   @State private var hasTrackedOnboardingStarted = false
   private let dataRecoverySettingsKey = "openDataRecovery"
+  private let persistenceBootstrap: SwiftDataManager.BootstrapResult
 
   #if DEBUG
     static let isDebugMode = true
@@ -102,6 +108,12 @@ struct My_YearApp: App {
   #endif
 
   init() {
+    let persistenceBootstrap = SwiftDataManager.bootstrapResult
+    self.persistenceBootstrap = persistenceBootstrap
+    if case .ready = persistenceBootstrap {
+      AnalyticsState.shared.setCalendarSnapshotProvider { CustomCalendarStore.shared.snapshot }
+    }
+
     AppFont.registerFonts()
     // The embed UI loads from WishKit's default hosted origin; wishConfig's
     // apiBaseURL only feeds programmatic calls (see WishConfiguration).
@@ -161,86 +173,92 @@ struct My_YearApp: App {
 
   var body: some Scene {
     WindowGroup {
-      RouterView(addNavigationStack: false, addModuleSupport: true) { _ in
-        ContentView()
-          .tint(.textSecondary)
-          .wishWhatsNewSheet()
-      }
-      .environment(\.dates, Self.cachedDates)
-      .onOpenURL { url in
-        guard url.scheme == "my-year" else { return }
+      switch persistenceBootstrap {
+      case .ready:
+        RouterView(addNavigationStack: false, addModuleSupport: true) { _ in
+          ContentView()
+            .tint(.textSecondary)
+            .wishWhatsNewSheet()
+        }
+        .environment(\.dates, Self.cachedDates)
+        .onOpenURL { url in
+          guard url.scheme == "my-year" else { return }
 
-        switch url.host {
-        case "clear":
-          let store = ValuationStore.shared
-          store.clearAllValuations()
-        case "calendar":
-          handleWidgetOpenURL(url)
-        case "quick-add":
-          handleWidgetQuickAddURL(url)
-        case "data-recovery":
-          isDataRecoveryPresented = true
-        default:
-          handleWidgetOpenURL(url)
-          break
+          switch url.host {
+          case "clear":
+            let store = ValuationStore.shared
+            store.clearAllValuations()
+          case "calendar":
+            handleWidgetOpenURL(url)
+          case "quick-add":
+            handleWidgetQuickAddURL(url)
+          case "data-recovery":
+            isDataRecoveryPresented = true
+          default:
+            handleWidgetOpenURL(url)
+            break
+          }
         }
-      }
-      .environmentObject(onboarding)
-      .environmentObject(reviewPrompter)
-      .environmentObject(upgradePrompter)
-      .fullScreenCover(
-        isPresented: onboardingPresentation,
-        onDismiss: {
+        .environmentObject(onboarding)
+        .environmentObject(reviewPrompter)
+        .environmentObject(upgradePrompter)
+        .fullScreenCover(
+          isPresented: onboardingPresentation,
+          onDismiss: {
+            updateTimelinePreferencePresentation()
+          }
+        ) {
+          OnboardingView {
+            completeOnboarding()
+          }
+        }
+        .fullScreenCover(isPresented: $isTimelinePreferenceSheetPresented) {
+          TimelinePreferenceChoiceSheet { mode in
+            TimelinePreferenceManager.shared.setMode(mode)
+            isTimelinePreferenceSheetPresented = false
+          }
+        }
+        .sheet(isPresented: $isDataRecoveryPresented) {
+          NavigationStack {
+            DataRecoveryView()
+          }
+        }
+        .sheet(item: $reviewPrompter.activePrompt) { context in
+          ReviewSatisfactionSheet(prompter: reviewPrompter, context: context)
+        }
+        .sheet(item: $upgradePrompter.activePrompt) { context in
+          OnboardingPaywall(
+            showsCloseButton: true,
+            isPresentedAsSheet: true,
+            trigger: context.trigger,
+            analyticsProperties: context.analyticsProperties,
+            onNext: {}
+          )
+        }
+        .onAppear {
           updateTimelinePreferencePresentation()
-        }
-      ) {
-        OnboardingView {
-          completeOnboarding()
-        }
-      }
-      .fullScreenCover(isPresented: $isTimelinePreferenceSheetPresented) {
-        TimelinePreferenceChoiceSheet { mode in
-          TimelinePreferenceManager.shared.setMode(mode)
-          isTimelinePreferenceSheetPresented = false
-        }
-      }
-      .sheet(isPresented: $isDataRecoveryPresented) {
-        NavigationStack {
-          DataRecoveryView()
-        }
-      }
-      .sheet(item: $reviewPrompter.activePrompt) { context in
-        ReviewSatisfactionSheet(prompter: reviewPrompter, context: context)
-      }
-      .sheet(item: $upgradePrompter.activePrompt) { context in
-        OnboardingPaywall(
-          showsCloseButton: true,
-          isPresentedAsSheet: true,
-          trigger: context.trigger,
-          analyticsProperties: context.analyticsProperties,
-          onNext: {}
-        )
-      }
-      .onAppear {
-        updateTimelinePreferencePresentation()
-        trackOnboardingStartedIfNeeded()
-        openDataRecoveryIfRequested()
-      }
-      .onChange(of: onboarding.hasSeenOnboarding) { _, hasSeenOnboarding in
-        if hasSeenOnboarding {
-          updateTimelinePreferencePresentation()
-        } else {
           trackOnboardingStartedIfNeeded()
+          openDataRecoveryIfRequested()
         }
-      }
-      .onChange(of: scenePhase) { _, phase in
-        guard phase == .active else { return }
-        Analytics.shared.flushQueuedWidgetEvents()
-        Analytics.shared.track(.appOpened)
-        openDataRecoveryIfRequested()
-        if onboarding.hasSeenOnboarding, reviewPrompter.activePrompt == nil {
-          upgradePrompter.considerTimedPrompt()
+        .onChange(of: onboarding.hasSeenOnboarding) { _, hasSeenOnboarding in
+          if hasSeenOnboarding {
+            updateTimelinePreferencePresentation()
+          } else {
+            trackOnboardingStartedIfNeeded()
+          }
         }
+        .onChange(of: scenePhase) { _, phase in
+          guard phase == .active else { return }
+          Analytics.shared.flushQueuedWidgetEvents()
+          Analytics.shared.track(.appOpened)
+          openDataRecoveryIfRequested()
+          if onboarding.hasSeenOnboarding, reviewPrompter.activePrompt == nil {
+            upgradePrompter.considerTimedPrompt()
+          }
+        }
+
+      case .unavailable(let message):
+        PersistenceUnavailableView(details: message)
       }
     }
   }

--- a/My Year/Services/Analytics/AnalyticsState.swift
+++ b/My Year/Services/Analytics/AnalyticsState.swift
@@ -7,6 +7,7 @@ final class AnalyticsState {
   static let shared = AnalyticsState()
 
   private let defaults: UserDefaults
+  private var calendarSnapshotProvider: (() -> CustomCalendarStoreSnapshot)?
   private let installDateKey = "analytics.install_date"
   private let distinctIDKey = "analytics.distinct_id"
   private let activationCompletedKey = "analytics.has_completed_activation"
@@ -18,8 +19,16 @@ final class AnalyticsState {
   private(set) var isPremiumUser = false
   private(set) var premiumStatusKnown = false
 
-  init(defaults: UserDefaults = .standard) {
+  init(
+    defaults: UserDefaults = .standard,
+    calendarSnapshotProvider: (() -> CustomCalendarStoreSnapshot)? = nil
+  ) {
     self.defaults = defaults
+    self.calendarSnapshotProvider = calendarSnapshotProvider
+  }
+
+  func setCalendarSnapshotProvider(_ provider: @escaping () -> CustomCalendarStoreSnapshot) {
+    calendarSnapshotProvider = provider
   }
 
   var distinctID: String {
@@ -90,7 +99,7 @@ final class AnalyticsState {
   }
 
   func standardProperties() -> [String: AnalyticsPropertyValue] {
-    let snapshot = CustomCalendarStore.shared.snapshot
+    let snapshot = calendarSnapshotProvider?() ?? CustomCalendarStoreSnapshot()
     let activeCalendars = snapshot.activeCalendars
 
     var properties: [String: AnalyticsPropertyValue] = [

--- a/My Year/Views/PersistenceUnavailableView.swift
+++ b/My Year/Views/PersistenceUnavailableView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct PersistenceUnavailableView: View {
+  let details: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 20) {
+      Image(systemName: "externaldrive.badge.exclamationmark")
+        .font(.system(size: 40))
+        .foregroundStyle(.orange)
+
+      Text("Your data could not be opened")
+        .font(.title.bold())
+
+      Text("Yearlit stopped before making any changes. Your existing data has not been replaced or deleted.")
+
+      Text(
+        "Close and reopen the app. If this screen returns, keep the app installed and contact support before trying to restore or reset anything."
+      )
+      .foregroundStyle(.secondary)
+
+      Text(details)
+        .font(.caption.monospaced())
+        .foregroundStyle(.secondary)
+        .textSelection(.enabled)
+    }
+    .frame(maxWidth: 520, maxHeight: .infinity, alignment: .center)
+    .padding(32)
+  }
+}

--- a/My YearTests/AnalyticsTests.swift
+++ b/My YearTests/AnalyticsTests.swift
@@ -69,6 +69,16 @@ struct AnalyticsTests {
     #expect(state.standardProperties()["mood_tracking_enabled"] == .bool(true))
   }
 
+  @Test func standardPropertiesDoNotRequireCalendarPersistence() {
+    let defaults = makeTestDefaults()
+    defer { cleanupTestDefaults(defaults) }
+
+    let state = AnalyticsState(defaults: defaults)
+
+    #expect(state.standardProperties()["calendar_count"] == .int(0))
+    #expect(state.standardProperties()["has_reminders_enabled"] == .bool(false))
+  }
+
   @Test func standardSnapshotPropertyKeysAreStableAndDocumented() throws {
     let defaults = makeTestDefaults()
     defer { cleanupTestDefaults(defaults) }

--- a/SharedModels/Sources/SharedModels/SharedModels.swift
+++ b/SharedModels/Sources/SharedModels/SharedModels.swift
@@ -1681,9 +1681,10 @@ public final class CustomCalendarStore: ObservableObject {
     }
 
     public nonisolated static func fetchCalendarsSnapshot(
-        container: ModelContainer = SwiftDataManager.container
+        container: ModelContainer? = nil
     ) -> [CustomCalendar] {
-        (try? fetchCalendars(container: container)) ?? []
+        guard let container = container ?? SwiftDataManager.availableContainer else { return [] }
+        return (try? fetchCalendars(container: container)) ?? []
     }
 
     public nonisolated static func normalizedCalendarOrder(_ calendars: [CustomCalendar]) -> [CustomCalendar] {
@@ -1949,9 +1950,10 @@ public final class ValuationStore: ObservableObject {
     }
 
     public nonisolated static func fetchValuationsSnapshot(
-        container: ModelContainer = SwiftDataManager.container
+        container: ModelContainer? = nil
     ) -> [String: DayValuation] {
-        (try? fetchValuations(container: container)) ?? [:]
+        guard let container = container ?? SwiftDataManager.availableContainer else { return [:] }
+        return (try? fetchValuations(container: container)) ?? [:]
     }
 
     public func getValuation(for date: Date) -> DayValuation? {

--- a/SharedModels/Sources/SharedModels/SwiftDataModels.swift
+++ b/SharedModels/Sources/SharedModels/SwiftDataModels.swift
@@ -474,34 +474,75 @@ extension HabitStackStepEntity {
 
 @available(iOS 17.0, macOS 14.0, *)
 public enum SwiftDataManager {
-    public static let container: ModelContainer = {
-        do {
-            let appGroupId = "group.sargon17.My-Year"
-            guard
-                let groupURL = FileManager.default
-                .containerURL(forSecurityApplicationGroupIdentifier: appGroupId)
-            else {
-                fatalError("Unable to resolve app group container for \(appGroupId)")
-            }
+    public enum BootstrapResult {
+        case ready(ModelContainer)
+        case unavailable(String)
+    }
 
-            let storeURL = groupURL.appendingPathComponent("SwiftDataStore.store", isDirectory: false)
-            let configuration = ModelConfiguration(
-                nil,
-                schema: nil,
-                url: storeURL,
-                allowsSave: true,
-                cloudKitDatabase: .automatic
-            )
-            return try ModelContainer(
-                for: HabitCalendarEntity.self,
-                CalendarEntryEntity.self,
-                DayValuationEntity.self,
-                HabitStackEntity.self,
-                HabitStackStepEntity.self,
-                configurations: configuration
-            )
-        } catch {
-            fatalError("Failed to initialise SwiftData container: \(error)")
+    private static let appGroupId = "group.sargon17.My-Year"
+
+    public static let bootstrapResult: BootstrapResult = {
+        guard
+            let groupURL = FileManager.default
+                .containerURL(forSecurityApplicationGroupIdentifier: appGroupId)
+        else {
+            return .unavailable("Unable to resolve app group container.")
         }
+
+        let storeURL = groupURL.appendingPathComponent("SwiftDataStore.store", isDirectory: false)
+        return bootstrap(storeURL: storeURL, makeContainer: makeContainer)
     }()
+
+    public static var isAvailable: Bool {
+        guard case .ready = bootstrapResult else { return false }
+        return true
+    }
+
+    public static var availableContainer: ModelContainer? {
+        guard case .ready(let container) = bootstrapResult else { return nil }
+        return container
+    }
+
+    public static var container: ModelContainer {
+        guard let container = availableContainer else {
+            preconditionFailure("SwiftData container accessed while persistence is unavailable")
+        }
+        return container
+    }
+
+    static func bootstrap(
+        storeURL: URL,
+        makeContainer: (URL) throws -> ModelContainer
+    ) -> BootstrapResult {
+        do {
+            return .ready(try makeContainer(storeURL))
+        } catch {
+            return .unavailable("Failed to open the existing data store: \(error.localizedDescription)")
+        }
+    }
+
+    private static func makeContainer(storeURL: URL) throws -> ModelContainer {
+        let configuration = ModelConfiguration(
+            nil,
+            schema: nil,
+            url: storeURL,
+            allowsSave: true,
+            cloudKitDatabase: .automatic
+        )
+        let container = try ModelContainer(
+            for: HabitCalendarEntity.self,
+            CalendarEntryEntity.self,
+            DayValuationEntity.self,
+            HabitStackEntity.self,
+            HabitStackStepEntity.self,
+            configurations: configuration
+        )
+        let context = ModelContext(container)
+        _ = try context.fetchCount(FetchDescriptor<HabitCalendarEntity>())
+        _ = try context.fetchCount(FetchDescriptor<CalendarEntryEntity>())
+        _ = try context.fetchCount(FetchDescriptor<DayValuationEntity>())
+        _ = try context.fetchCount(FetchDescriptor<HabitStackEntity>())
+        _ = try context.fetchCount(FetchDescriptor<HabitStackStepEntity>())
+        return container
+    }
 }

--- a/SharedModels/Tests/SharedModelsTests/SwiftDataBootstrapTests.swift
+++ b/SharedModels/Tests/SharedModelsTests/SwiftDataBootstrapTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftData
+import Testing
+
+@testable import SharedModels
+
+@Suite("SwiftData bootstrap")
+struct SwiftDataBootstrapTests {
+  @Test("A container creation failure is reported without substituting another store")
+  func reportsContainerCreationFailure() {
+    struct ExpectedFailure: Error {}
+    let expectedURL = URL(fileURLWithPath: "/existing-user-data/SwiftDataStore.store")
+    var receivedURL: URL?
+
+    let result = SwiftDataManager.bootstrap(storeURL: expectedURL) { storeURL in
+      receivedURL = storeURL
+      throw ExpectedFailure()
+    }
+
+    #expect(receivedURL == expectedURL)
+    guard case .unavailable = result else {
+      Issue.record("Expected the existing store failure to be surfaced")
+      return
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- replace fatal persistence startup with an explicit read-only unavailable state
- health-check every persisted entity family before enabling the writable app
- prevent analytics, notifications, widgets, and App Intents from opening an unavailable store
- never create or switch to an in-memory/substitute store

## Verification
- `swift test` — 24 SharedModels tests passed
- generic iOS Simulator build passed, including widget extensions
- independent strict review completed; both blocker findings fixed

No schema or data-contract changes.