### PR TITLE
feat: grid visualization styles (dots, scaled dots, sparkles, crosses)

### DIFF
--- a/My Year/Components/Calendars/GridView.swift
+++ b/My Year/Components/Calendars/GridView.swift
@@ -4,9 +4,11 @@ import UIKit
 
 struct GridView: View {
   @Environment(\.colorScheme) private var colorScheme
+  @AppStorage(AppStorageKeys.gridVisualizationStyle)
+  private var visualizationStyle: GridVisualizationStyle = .dot
 
   let handleDayTap: (Date) -> Void
-  let mappedDays: [(date: Date, color: Color)]
+  let mappedDays: [GridDay]
   let disabledDates: Set<Date>
   let rippleOriginDate: Date?
   let rippleTrigger: Int
@@ -14,7 +16,7 @@ struct GridView: View {
 
   init(
     handleDayTap: @escaping (Date) -> Void,
-    mappedDays: [(date: Date, color: Color)],
+    mappedDays: [GridDay],
     disabledDates: Set<Date>,
     rippleOriginDate: Date? = nil,
     rippleTrigger: Int = 0
@@ -73,7 +75,7 @@ struct GridView: View {
         let phase = timelineDate.map { ripplePhase(for: ripple, at: $0) } ?? 0
         drawDot(
           context: &context,
-          color: day.color,
+          day: day,
           center: layout.center(for: index),
           ripple: ripple,
           phase: phase
@@ -115,19 +117,22 @@ struct GridView: View {
 
   private func drawDot(
     context: inout GraphicsContext,
-    color baseColor: Color,
+    day: GridDay,
     center: CGPoint,
     ripple: CalendarGridRipple,
     phase: Double
   ) {
+    let baseColor = day.color
+    let markSize = visualizationStyle.markSize(base: CalendarGridLayout.dotSize, fillRatio: day.fillRatio)
+
     guard phase != 0 else {
       let rect = CGRect(
-        x: center.x - (CalendarGridLayout.dotSize / 2),
-        y: center.y - (CalendarGridLayout.dotSize / 2),
-        width: CalendarGridLayout.dotSize,
-        height: CalendarGridLayout.dotSize
+        x: center.x - (markSize / 2),
+        y: center.y - (markSize / 2),
+        width: markSize,
+        height: markSize
       )
-      context.fill(Path(roundedRect: rect, cornerRadius: 3), with: .color(baseColor))
+      context.fill(visualizationStyle.path(in: rect), with: .color(baseColor))
       return
     }
 
@@ -154,29 +159,16 @@ struct GridView: View {
       layer.scaleBy(x: scale, y: scale)
 
       let rect = CGRect(
-        x: -CalendarGridLayout.dotSize / 2,
-        y: -CalendarGridLayout.dotSize / 2,
-        width: CalendarGridLayout.dotSize,
-        height: CalendarGridLayout.dotSize
+        x: -markSize / 2,
+        y: -markSize / 2,
+        width: markSize,
+        height: markSize
       )
-      let path = Path(roundedRect: rect, cornerRadius: 3)
+      let path = visualizationStyle.path(in: rect)
       layer.fill(path, with: .color(color))
 
       if isHighlighting {
-        let gradient = Gradient(colors: [
-          Color.white.opacity((colorScheme == .dark ? 0.2 : 0.28) * highlightForce),
-          Color.white.opacity((colorScheme == .dark ? 0.06 : 0.08) * highlightForce),
-          .clear
-        ])
-        layer.fill(
-          path,
-          with: .linearGradient(
-            gradient,
-            startPoint: CGPoint(x: rect.minX, y: rect.minY),
-            endPoint: CGPoint(x: rect.maxX, y: rect.maxY)
-          )
-        )
-        layer.stroke(path, with: .color(Color.white.opacity(0.18 * highlightForce)), lineWidth: 1)
+        drawHighlight(layer: &layer, path: path, rect: rect, highlightForce: highlightForce)
       }
 
       if isRecoiling {
@@ -184,6 +176,28 @@ struct GridView: View {
         layer.fill(path, with: .color(Color.black.opacity(opacity)))
       }
     }
+  }
+
+  private func drawHighlight(
+    layer: inout GraphicsContext,
+    path: Path,
+    rect: CGRect,
+    highlightForce: Double
+  ) {
+    let gradient = Gradient(colors: [
+      Color.white.opacity((colorScheme == .dark ? 0.2 : 0.28) * highlightForce),
+      Color.white.opacity((colorScheme == .dark ? 0.06 : 0.08) * highlightForce),
+      .clear
+    ])
+    layer.fill(
+      path,
+      with: .linearGradient(
+        gradient,
+        startPoint: CGPoint(x: rect.minX, y: rect.minY),
+        endPoint: CGPoint(x: rect.maxX, y: rect.maxY)
+      )
+    )
+    layer.stroke(path, with: .color(Color.white.opacity(0.18 * highlightForce)), lineWidth: 1)
   }
 
   private func rippleOriginIndex() -> Int? {

--- a/My Year/Components/Calendars/GridVisualizationStyle.swift
+++ b/My Year/Components/Calendars/GridVisualizationStyle.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+/// One day cell, ready for canvas rendering.
+struct GridDay {
+  let date: Date
+  let color: Color
+  /// Normalized 0...1 intensity for the day (entry count vs target/typical volume).
+  let fillRatio: Double
+}
+
+/// App-wide style for the year grid marks. Add a case here to introduce a new visualization.
+enum GridVisualizationStyle: String, CaseIterable, Identifiable {
+  case dot
+  case scaledDot
+  case sparkle
+  case cross
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .dot: return String(localized: "Dots")
+    case .scaledDot: return String(localized: "Scaled Dots")
+    case .sparkle: return String(localized: "Sparkles")
+    case .cross: return String(localized: "Crosses")
+    }
+  }
+
+  /// Side of the mark's bounding square for a given base dot size.
+  /// Layout and hit-testing keep using the base size; only the drawn mark changes.
+  func markSize(base: CGFloat, fillRatio: Double) -> CGFloat {
+    switch self {
+    case .dot:
+      return base
+    case .scaledDot:
+      return base * (0.45 + (0.75 * fillRatio))
+    case .sparkle, .cross:
+      // Thin shapes need a bigger bounding box to match the dot's visual weight.
+      return base * 1.3
+    }
+  }
+
+  func path(in rect: CGRect) -> Path {
+    switch self {
+    case .dot, .scaledDot:
+      return Path(roundedRect: rect, cornerRadius: min(rect.width, rect.height) * 0.3)
+    case .sparkle:
+      return Self.sparklePath(in: rect)
+    case .cross:
+      return Self.crossPath(in: rect)
+    }
+  }
+
+  /// Four-point star with concave sides.
+  private static func sparklePath(in rect: CGRect) -> Path {
+    let center = CGPoint(x: rect.midX, y: rect.midY)
+    let radius = min(rect.width, rect.height) / 2
+    // 0 = needle-thin, 1 = straight-sided diamond.
+    let waist: CGFloat = 0.3
+
+    let top = CGPoint(x: center.x, y: center.y - radius)
+    let right = CGPoint(x: center.x + radius, y: center.y)
+    let bottom = CGPoint(x: center.x, y: center.y + radius)
+    let left = CGPoint(x: center.x - radius, y: center.y)
+
+    func control(dx: CGFloat, dy: CGFloat) -> CGPoint {
+      CGPoint(x: center.x + (dx * radius * waist), y: center.y + (dy * radius * waist))
+    }
+
+    var path = Path()
+    path.move(to: top)
+    path.addQuadCurve(to: right, control: control(dx: 1, dy: -1))
+    path.addQuadCurve(to: bottom, control: control(dx: 1, dy: 1))
+    path.addQuadCurve(to: left, control: control(dx: -1, dy: 1))
+    path.addQuadCurve(to: top, control: control(dx: -1, dy: -1))
+    path.closeSubpath()
+    return path
+  }
+
+  /// Plus sign made of two crossed rounded bars.
+  private static func crossPath(in rect: CGRect) -> Path {
+    let armWidth = min(rect.width, rect.height) * 0.34
+    let corner = CGSize(width: armWidth * 0.35, height: armWidth * 0.35)
+
+    var path = Path()
+    path.addRoundedRect(
+      in: CGRect(x: rect.midX - (armWidth / 2), y: rect.minY, width: armWidth, height: rect.height),
+      cornerSize: corner
+    )
+    path.addRoundedRect(
+      in: CGRect(x: rect.minX, y: rect.midY - (armWidth / 2), width: rect.width, height: armWidth),
+      cornerSize: corner
+    )
+    return path
+  }
+}

--- a/My Year/Components/Calendars/OverallGridView.swift
+++ b/My Year/Components/Calendars/OverallGridView.swift
@@ -9,8 +9,10 @@ struct OverallGridView: View {
   let year: Int
 
   @Environment(\.colorScheme) var colorScheme
+  @AppStorage(AppStorageKeys.gridVisualizationStyle)
+  private var visualizationStyle: GridVisualizationStyle = .dot
   let today: Date = DateInRegion(region: .current).date
-  @State private var mappedDays: [(date: Date, color: Color)] = []
+  @State private var mappedDays: [GridDay] = []
 
   private var dates: [Date] {
     getYearDatesArray(for: year)
@@ -26,14 +28,16 @@ struct OverallGridView: View {
 
       Canvas { context, _ in
         for index in mappedDays.indices {
+          let day = mappedDays[index]
           let center = layout.center(for: index)
+          let markSize = visualizationStyle.markSize(base: CalendarGridLayout.dotSize, fillRatio: day.fillRatio)
           let rect = CGRect(
-            x: center.x - (CalendarGridLayout.dotSize / 2),
-            y: center.y - (CalendarGridLayout.dotSize / 2),
-            width: CalendarGridLayout.dotSize,
-            height: CalendarGridLayout.dotSize
+            x: center.x - (markSize / 2),
+            y: center.y - (markSize / 2),
+            width: markSize,
+            height: markSize
           )
-          context.fill(Path(roundedRect: rect, cornerRadius: 3), with: .color(mappedDays[index].color))
+          context.fill(visualizationStyle.path(in: rect), with: .color(day.color))
         }
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -68,17 +72,19 @@ struct OverallGridView: View {
     ].joined(separator: "|")
   }
 
-  private func mappedDays(from zByDay: [Double]) -> [(date: Date, color: Color)] {
+  private func mappedDays(from zByDay: [Double]) -> [GridDay] {
     let futureColor = futureDayColor()
     let todayColor = activeDayColor()
     let missedColor = missedDayColor()
     let todayBucket = LocalDayCalendar.startOfDay(for: today)
-    return zip(dates, zByDay).map { day, z -> (date: Date, color: Color) in
+    return zip(dates, zByDay).map { day, z -> GridDay in
       let dayBucket = day  // dates from getYearDatesArray are pre-bucketed to midnight
-      if dayBucket > todayBucket { return (day, futureColor) }
-      if z <= 0 { return (day, dayBucket == todayBucket ? todayColor : missedColor) }
-      let opacity = min(1, max(0.2, z))
-      return (day, accentColor.opacity(opacity))
+      if dayBucket > todayBucket { return GridDay(date: day, color: futureColor, fillRatio: 0) }
+      if z <= 0 {
+        return GridDay(date: day, color: dayBucket == todayBucket ? todayColor : missedColor, fillRatio: 0)
+      }
+      let intensity = min(1, max(0.2, z))
+      return GridDay(date: day, color: accentColor.opacity(intensity), fillRatio: intensity)
     }
   }
 }

--- a/My Year/Config/AppStorageKeys.swift
+++ b/My Year/Config/AppStorageKeys.swift
@@ -5,6 +5,7 @@ enum AppStorageKeys {
   static let runtimeDebugEnabled = "runtimeDebugEnabled"
   static let cleanScreenshotsEnabled = "cleanScreenshotsEnabled"
   static let wandFillForce = "wandFillForce"
+  static let gridVisualizationStyle = "gridVisualizationStyle"
   static let milestoneCelebrationsEnabled = "milestoneCelebrationsEnabled"
   static let streakMilestoneCelebrationsEnabled = "streakMilestoneCelebrationsEnabled"
   static let showedUpMilestoneCelebrationsEnabled = "showedUpMilestoneCelebrationsEnabled"

--- a/My Year/Utils/Calendar/CalendarRenderSnapshot.swift
+++ b/My Year/Utils/Calendar/CalendarRenderSnapshot.swift
@@ -11,7 +11,7 @@ struct CalendarRenderSnapshot {
   let visibleGridDates: [Date]
   let your365HeaderTitle: String?
   let currentPeriodReferenceDate: Date?
-  let mappedGridDays: [(date: Date, color: Color)]
+  let mappedGridDays: [GridDay]
   let disabledGridDates: Set<Date>
   let cacheKey: String
 }
@@ -134,27 +134,32 @@ enum CalendarRenderSnapshotCache {
     dates: [Date],
     today: Date,
     your365Snapshot: Your365Snapshot?
-  ) -> [(date: Date, color: Color)] {
+  ) -> [GridDay] {
     let cellsByDate = Dictionary(uniqueKeysWithValues: your365Snapshot?.cells.map { ($0.date, $0) } ?? [])
     let counts = calendar.entries.values.map { $0.count }
     let scale = precomputeRobustDotScale(for: counts)
 
     return dates.map { date in
       if let cell = cellsByDate[date] {
-        return (
+        let isTracked = cell.state != .future && cell.state != .notTracked
+        return GridDay(
           date: date,
           color: colorForYour365Day(
             cell,
             calendar: calendar,
             today: today,
             precomputedScale: scale
-          )
+          ),
+          fillRatio: isTracked
+            ? fillRatioForDay(date, calendar: calendar, today: today, precomputedScale: scale)
+            : 0
         )
       }
 
-      return (
+      return GridDay(
         date: date,
-        color: colorForDay(date, calendar: calendar, today: today, precomputedScale: scale)
+        color: colorForDay(date, calendar: calendar, today: today, precomputedScale: scale),
+        fillRatio: fillRatioForDay(date, calendar: calendar, today: today, precomputedScale: scale)
       )
     }
   }

--- a/My Year/Utils/Calendar/colorForDay.swift
+++ b/My Year/Utils/Calendar/colorForDay.swift
@@ -11,6 +11,30 @@ func colorForDay(
     colorForDay(day, calendar: calendar, today: today, precomputedScale: precomputeRobustDotScale(for: counts))
 }
 
+/// Same normalization the color uses, exposed as a number so styles can also encode it as mark size.
+func fillRatioForDay(
+    _ day: Date,
+    calendar: CustomCalendar,
+    today: Date,
+    precomputedScale: Double
+) -> Double {
+    let comparisonDate = calendar.bucketDate(for: today)
+    let bucketDate = calendar.bucketDate(for: day)
+
+    guard bucketDate <= comparisonDate, let entry = calendar.entry(for: day) else {
+        return 0
+    }
+
+    switch calendar.trackingType {
+    case .binary:
+        return entry.completed ? 1 : 0
+    case .counter:
+        return counterDotFillRatio(count: entry.count, precomputedScale: precomputedScale)
+    case .multipleDaily:
+        return multipleDailyDotFillRatio(count: entry.count, dailyTarget: calendar.dailyTarget)
+    }
+}
+
 /// Variant for tight loops: pass a precomputed scale to avoid recomputing it per cell.
 func colorForDay(
     _ day: Date,

--- a/My Year/Views/MoodTrackingCalendar.swift
+++ b/My Year/Views/MoodTrackingCalendar.swift
@@ -18,6 +18,8 @@ struct MoodTrackingCalendar: View {
   let store = ValuationStore.shared
   @AppStorage(AppStorageKeys.isMoodTrackingEnabled) var isMoodTrackingEnabled: Bool = false
   @AppStorage("lastMoodPromptDayKey") private var lastMoodPromptDayKey: String = ""
+  @AppStorage(AppStorageKeys.gridVisualizationStyle)
+  private var visualizationStyle: GridVisualizationStyle = .dot
   @Environment(\.router) private var router
 
   @State private var valuationPopupDate: Date?
@@ -38,6 +40,12 @@ struct MoodTrackingCalendar: View {
     }
 
     return day == store.currentDayNumber ? activeDayColor() : missedDayColor()
+  }
+
+  /// Mood valuations are single entries, so a valuated day counts as full.
+  private func fillRatioForDay(_ day: Int) -> Double {
+    guard day <= store.currentDayNumber else { return 0 }
+    return store.getValuation(for: store.dateForDay(day)) == nil ? 0 : 1
   }
 
   private func handleDayTap(_ day: Int) {
@@ -154,13 +162,17 @@ struct MoodTrackingCalendar: View {
         Canvas { context, _ in
           for day in 0..<store.numberOfDaysInYear {
             let center = layout.center(for: day)
-            let rect = CGRect(
-              x: center.x - (CalendarGridLayout.dotSize / 2),
-              y: center.y - (CalendarGridLayout.dotSize / 2),
-              width: CalendarGridLayout.dotSize,
-              height: CalendarGridLayout.dotSize
+            let markSize = visualizationStyle.markSize(
+              base: CalendarGridLayout.dotSize,
+              fillRatio: fillRatioForDay(day)
             )
-            context.fill(Path(roundedRect: rect, cornerRadius: 3), with: .color(colorForDay(day)))
+            let rect = CGRect(
+              x: center.x - (markSize / 2),
+              y: center.y - (markSize / 2),
+              width: markSize,
+              height: markSize
+            )
+            context.fill(visualizationStyle.path(in: rect), with: .color(colorForDay(day)))
           }
         }
         .contentShape(Rectangle())

--- a/My Year/Views/Settings/Features.swift
+++ b/My Year/Views/Settings/Features.swift
@@ -5,6 +5,7 @@ struct YearExperienceSection: View {
   @ObservedObject private var timelinePreference = TimelinePreferenceManager.shared
   @AppStorage(AppStorageKeys.isMoodTrackingEnabled) var isMoodTrackingEnabled: Bool = false
   @AppStorage(AppStorageKeys.isRecapViewEnabled) var isRecapViewEnabled: Bool = false
+  @AppStorage(AppStorageKeys.gridVisualizationStyle) var gridVisualizationStyle: GridVisualizationStyle = .dot
 
   private var selectedMode: Binding<CalendarTimelineMode> {
     Binding(
@@ -51,6 +52,12 @@ struct YearExperienceSection: View {
       Text(timelineHelperCopy)
         .font(.footnote)
         .foregroundStyle(.secondary)
+
+      Picker("Grid style", selection: $gridVisualizationStyle) {
+        ForEach(GridVisualizationStyle.allCases) { style in
+          Text(style.title).tag(style)
+        }
+      }
 
       Toggle("Mood Tracking", isOn: moodTrackingBinding)
       Toggle("Recap View", isOn: recapViewBinding)


### PR DESCRIPTION
## What

Adds an app-wide "Grid style" setting with four mark shapes for the year grids:

- **Dots** — current rounded squares (default, no visual change)
- **Scaled Dots** — mark size encodes the entry-count fill ratio, with the same normalization the color intensity uses
- **Sparkles** — four-point star marks
- **Crosses** — plus-shaped marks

## How

- New `GridVisualizationStyle` enum holds the shape catalog. A new visualization only needs a new case with its `path(in:)`.
- New `GridDay` struct carries `fillRatio` (0...1) to the canvas, computed with the existing `DotFillRatio` normalization (`fillRatioForDay` next to `colorForDay`).
- Applied in the habit grid (`GridView`, ripple animation included), the overview grid (`OverallGridView`), and the mood year view.
- Stored via `@AppStorage`; picker in Settings → Your Year.
- Layout and hit-testing keep the base dot size; only the drawn mark changes.

## Verification

- Device and simulator builds pass; SwiftLint clean against the baseline.
- All four styles verified on the simulator through the in-app picker (habit grid, overview, mood view).

## Out of scope

Widgets, share cards, and the onboarding grid keep the rounded-square dots. Style names are not localized yet. No analytics event on style change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)