### PR TITLE
fix: ease scaled dot size with sqrt so average days stay visible

### DIFF
--- a/My Year/Components/Calendars/GridVisualizationStyle.swift
+++ b/My Year/Components/Calendars/GridVisualizationStyle.swift
@@ -33,7 +33,9 @@ enum GridVisualizationStyle: String, CaseIterable, Identifiable {
     case .dot:
       return base
     case .scaledDot:
-      return base * (0.45 + (0.75 * fillRatio))
+      // sqrt maps value to area instead of diameter, so days near the average
+      // stay clearly visible next to outlier days instead of vanishing.
+      return base * (0.45 + (0.75 * sqrt(fillRatio)))
     case .sparkle, .cross:
       // Thin shapes need a bigger bounding box to match the dot's visual weight.
       return base * 1.3


### PR DESCRIPTION
## What

In the Scaled Dots grid style, days near the average were almost invisible next to outlier days. Example: a reading habit with most days at 10–20 pages and a few at 50 — only the 50-page days had real visual weight.

## Why

The mark size mapped the normalized fill ratio linearly to **diameter**, but the eye compares **area** (diameter squared). An average day got ~35% of the top day's area.

## How

One line in `GridVisualizationStyle.markSize`: ease the ratio with `sqrt` before it becomes a diameter, so area stays roughly proportional to the value. Average days go from ~35% to ~55% of the top day's area; the best days stay the biggest. Same easing `multipleDailyDotFillRatio` already uses.

## Verification

Simulator build passes; SwiftLint clean against the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)