### PR TITLE
feat: add the Recent Weeks lock screen widget

### DIFF
--- a/HabitsWidget/HabitWeeksWidget.swift
+++ b/HabitsWidget/HabitWeeksWidget.swift
@@ -1,0 +1,114 @@
+//
+//  HabitWeeksWidget.swift
+//  HabitsWidget
+//
+//  Lock Screen widget: the last weeks of one habit as a small grid.
+//
+
+import SharedModels
+import SwiftUI
+import WidgetKit
+
+private let weekRows = 3
+private let daysPerWeek = 7
+
+struct HabitWeeksWidgetEntryView: View {
+  var entry: SimpleEntry
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.widgetRenderingMode) private var widgetRenderingMode
+
+  private let visualizationStyle = GridVisualizationStyle.stored()
+
+  var body: some View {
+    let renderingMode = WidgetStyle.RenderingMode(widgetRenderingMode)
+    let snapshot = HabitWidgetGridSnapshot.make(
+      family: .accessoryRectangular,
+      calendar: entry.calendar,
+      timelineMode: entry.timelineMode,
+      referenceDate: entry.date,
+      backgroundColor: WidgetStyle.widgetBackgroundColor(for: colorScheme, renderingMode: renderingMode),
+      textPrimaryColor: WidgetStyle.primaryTextColor(for: colorScheme, renderingMode: renderingMode),
+      inactiveRatio: WidgetStyle.futureDotFillRatio,
+      renderingMode: renderingMode
+    )
+
+    VStack(alignment: .leading, spacing: 2) {
+      if let calendar = entry.calendar {
+        Text(calendar.name)
+          .font(AppFont.mono(11))
+          .fontWeight(.heavy)
+          .foregroundColor(renderingMode.isMonochrome ? .primary : Color("text-primary"))
+          .lineLimit(1)
+          .minimumScaleFactor(0.7)
+      }
+
+      HabitWeeksDotGrid(days: snapshot.days, style: visualizationStyle)
+    }
+    .containerBackground(.clear, for: .widget)
+    .widgetURL(
+      entry.calendar.map { calendar in
+        widgetDeepLink(
+          host: "calendar",
+          calendarId: calendar.id.uuidString,
+          widgetKind: WidgetAnalyticsKind.habitWeeks.rawValue,
+          widgetAction: "open_calendar"
+        )
+      }
+    )
+  }
+}
+
+private struct HabitWeeksDotGrid: View {
+  let days: [HabitWidgetGridDay]
+  let style: GridVisualizationStyle
+
+  var body: some View {
+    GeometryReader { geometry in
+      let columns = CGFloat(daysPerWeek)
+      let rows = CGFloat(weekRows)
+      let dotSize = min(geometry.size.height / rows, geometry.size.width / columns) * 0.62
+      let horizontalSpacing = max(1, (geometry.size.width - dotSize * columns) / (columns - 1))
+      let verticalSpacing = max(1, (geometry.size.height - dotSize * rows) / (rows - 1))
+
+      VStack(spacing: verticalSpacing) {
+        ForEach(0..<weekRows, id: \.self) { row in
+          HStack(spacing: horizontalSpacing) {
+            ForEach(0..<daysPerWeek, id: \.self) { col in
+              let index = (row * daysPerWeek) + col
+              if index < days.count {
+                let gridDay = days[index]
+                WidgetGridDot(
+                  color: gridDay.color,
+                  dotSize: dotSize,
+                  accentable: gridDay.accentable,
+                  style: style,
+                  fillRatio: gridDay.fillRatio
+                )
+              } else {
+                Color.clear.frame(width: dotSize, height: dotSize)
+              }
+            }
+          }
+        }
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+  }
+}
+
+struct HabitWeeksWidget: Widget {
+  let kind: String = WidgetKinds.habitWeeks
+
+  var body: some WidgetConfiguration {
+    AppIntentConfiguration(
+      kind: kind,
+      intent: ConfigurationAppIntent.self,
+      provider: Provider(analyticsKind: .habitWeeks)
+    ) { entry in
+      HabitWeeksWidgetEntryView(entry: entry)
+    }
+    .configurationDisplayName("Recent Weeks")
+    .description("The last weeks of your habit, on the Lock Screen.")
+    .supportedFamilies([.accessoryRectangular])
+  }
+}

--- a/HabitsWidget/HabitWidgetGridSnapshot.swift
+++ b/HabitsWidget/HabitWidgetGridSnapshot.swift
@@ -239,6 +239,10 @@ private struct HabitWidgetGridSnapshotBuilder {
   }
 
   private func datesForFamily(today: Date, your365Snapshot: Your365Snapshot?) -> [Date] {
+    if family == .accessoryRectangular {
+      return accessoryDates(today: today)
+    }
+
     if let calendar, calendar.cadence == .weekly {
       return family == .systemSmall ? recentWeeks(from: today, weeks: 35) : yearWeeks(containing: today)
     }
@@ -248,6 +252,21 @@ private struct HabitWidgetGridSnapshotBuilder {
     }
 
     return family == .systemSmall ? recentDates(from: today, days: 35) : yearDates(containing: today)
+  }
+
+  /// Whole weeks aligned to the week start, so the Lock Screen rows read as a calendar.
+  private func accessoryDates(today: Date) -> [Date] {
+    if let calendar, calendar.cadence == .weekly {
+      return recentWeeks(from: today, weeks: 21)
+    }
+    let dayCalendar = LocalDayCalendar.calendar
+    let weekStart = LocalDayCalendar.startOfWeek(for: today)
+    guard let start = dayCalendar.date(byAdding: .weekOfYear, value: -2, to: weekStart),
+      let end = dayCalendar.date(byAdding: .day, value: 6, to: weekStart)
+    else {
+      return []
+    }
+    return buildDates(from: start, to: end)
   }
 
   private func smallYour365Dates(today: Date, snapshot: Your365Snapshot) -> [Date] {

--- a/HabitsWidget/HabitsWidget.swift
+++ b/HabitsWidget/HabitsWidget.swift
@@ -12,6 +12,8 @@ import UIKit
 import WidgetKit
 
 struct Provider: AppIntentTimelineProvider {
+  var analyticsKind: WidgetAnalyticsKind = .habits
+
   func placeholder(in _: Context) -> SimpleEntry {
     makeEntry(for: ConfigurationAppIntent.defaultCalendar, date: Date())
   }
@@ -32,7 +34,7 @@ struct Provider: AppIntentTimelineProvider {
       } ?? entry.timelineMode
 
       WidgetAnalyticsQueue.shared.enqueueTimelineLoaded(properties: [
-        "widget_kind": .string(WidgetAnalyticsKind.habits.rawValue),
+        "widget_kind": .string(analyticsKind.rawValue),
         "widget_family": .string(widgetFamilyName(context.family)),
         "has_calendar": .bool(entry.calendar != nil),
         "cadence": .string(entry.calendar?.cadence.rawValue ?? "unknown"),
@@ -520,11 +522,12 @@ private func widgetFamilyName(_ family: WidgetFamily) -> String {
   case .systemSmall: return WidgetAnalyticsFamily.systemSmall.rawValue
   case .systemMedium: return WidgetAnalyticsFamily.systemMedium.rawValue
   case .systemLarge: return WidgetAnalyticsFamily.systemLarge.rawValue
+  case .accessoryRectangular: return WidgetAnalyticsFamily.accessoryRectangular.rawValue
   default: return WidgetAnalyticsFamily.other.rawValue
   }
 }
 
-private func widgetDeepLink(
+func widgetDeepLink(
   host: String,
   calendarId: String?,
   widgetKind: String,

--- a/HabitsWidget/HabitsWidgetBundle.swift
+++ b/HabitsWidget/HabitsWidgetBundle.swift
@@ -12,6 +12,7 @@ import WidgetKit
 struct HabitsWidgetBundle: WidgetBundle {
     var body: some Widget {
         HabitsWidget()
+        HabitWeeksWidget()
         // HabitsWidgetControl()
     }
 }

--- a/SharedModels/Sources/SharedModels/WidgetAnalyticsQueue.swift
+++ b/SharedModels/Sources/SharedModels/WidgetAnalyticsQueue.swift
@@ -4,12 +4,14 @@ public enum WidgetAnalyticsKind: String, Codable, CaseIterable {
     case year
     case habits
     case streak
+    case habitWeeks = "habit_weeks"
 }
 
 public enum WidgetAnalyticsFamily: String, Codable, CaseIterable {
     case systemSmall
     case systemMedium
     case systemLarge
+    case accessoryRectangular
     case other
 }
 

--- a/SharedModels/Sources/SharedModels/WidgetReload.swift
+++ b/SharedModels/Sources/SharedModels/WidgetReload.swift
@@ -14,6 +14,7 @@ public enum WidgetReload {
         case year
         case habits
         case streak
+        case habitWeeks
 
         var widgetKind: String {
             switch self {
@@ -23,6 +24,8 @@ public enum WidgetReload {
                 WidgetKinds.habits
             case .streak:
                 WidgetKinds.streak
+            case .habitWeeks:
+                WidgetKinds.habitWeeks
             }
         }
     }
@@ -54,7 +57,7 @@ public enum WidgetReload {
     }
 
     public static func scheduleHabitWidgetsReload(debounce: TimeInterval = 0.5) {
-        scheduleReload(of: [.habits, .streak], debounce: debounce)
+        scheduleReload(of: [.habits, .streak, .habitWeeks], debounce: debounce)
     }
 
     public static func scheduleYearWidgetReload(debounce: TimeInterval = 0.5) {
@@ -90,4 +93,5 @@ public enum WidgetKinds {
     public static let year = "YearWidget"
     public static let habits = "HabitsWidget"
     public static let streak = "StreakWidget"
+    public static let habitWeeks = "HabitWeeksWidget"
 }


### PR DESCRIPTION
## Summary

Adds a Lock Screen widget, "Recent Weeks", in the rectangular accessory slot. It shows one habit as a 7×3 grid of the last three weeks, with rows aligned to the week start and the current week last. Weekly habits show one mark for each of the last 21 weeks. A tap opens the habit in the app.

## How it is built

- `HabitWeeksWidget.swift` holds the entry view, the fixed 7×3 dot grid, and the widget declaration.
- The widget reuses the existing `Provider` and `SimpleEntry`. `Provider` gained an `analyticsKind` property so timeline analytics report `habit_weeks`.
- `HabitWidgetGridSnapshotBuilder.datesForFamily` gained an `.accessoryRectangular` branch, so all date-window logic stays in the builder.
- The stored grid visualization style and the monochrome Lock Screen colors come from the existing snapshot and dot views.
- `WidgetKinds`, `WidgetReload`, and the analytics enums gained a `habitWeeks` entry, so habit changes reload the new widget.

## Verification

- `xcodebuild` for the "My Year" scheme: BUILD SUCCEEDED.
- SwiftLint: zero warnings on the new file, no new warnings in the edited files.
- Ponytail and code-quality review passes applied. The new file went from 224 to 114 lines.
- Not verified on the simulator Lock Screen. Please add the widget on a Lock Screen (touch and hold → Customize → Yearlit → Recent Weeks) and check the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
