### PR TITLE
feat: choose the grid visualization per widget

### DIFF
--- a/HabitsWidget/HabitWeeksWidget.swift
+++ b/HabitsWidget/HabitWeeksWidget.swift
@@ -17,8 +17,6 @@ struct HabitWeeksWidgetEntryView: View {
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.widgetRenderingMode) private var widgetRenderingMode
 
-  private let visualizationStyle = GridVisualizationStyle.stored()
-
   var body: some View {
     let renderingMode = WidgetStyle.RenderingMode(widgetRenderingMode)
     let snapshot = HabitWidgetGridSnapshot.make(
@@ -42,7 +40,7 @@ struct HabitWeeksWidgetEntryView: View {
           .minimumScaleFactor(0.7)
       }
 
-      HabitWeeksDotGrid(days: snapshot.days, style: visualizationStyle)
+      HabitWeeksDotGrid(days: snapshot.days, style: .scaledDot)
     }
     .containerBackground(.clear, for: .widget)
     .widgetURL(

--- a/HabitsWidget/HabitsWidget.swift
+++ b/HabitsWidget/HabitsWidget.swift
@@ -114,7 +114,8 @@ struct HorizontalCalendarGrid: View {
     backgroundColor: Color,
     textPrimaryColor: Color,
     inactiveRatio: Double,
-    renderingMode: WidgetStyle.RenderingMode
+    renderingMode: WidgetStyle.RenderingMode,
+    visualizationStyle: GridVisualizationStyle
   ) {
     self.family = family
     self.calendar = calendar
@@ -127,7 +128,7 @@ struct HorizontalCalendarGrid: View {
     self.textPrimaryColor = textPrimaryColor
     self.inactiveRatio = inactiveRatio
     self.renderingMode = renderingMode
-    visualizationStyle = GridVisualizationStyle.stored()
+    self.visualizationStyle = visualizationStyle
     switch family {
     case .systemLarge:
       dotSize = 10.0
@@ -405,7 +406,8 @@ struct HabitsWidgetEntryView: View {
         backgroundColor: backgroundColor,
         textPrimaryColor: primaryTextColor,
         inactiveRatio: inactiveRatio,
-        renderingMode: renderingMode
+        renderingMode: renderingMode,
+        visualizationStyle: entry.configuration.visualizationStyle.resolved()
       )
       .containerBackground(backgroundColor, for: .widget)
       .widgetURL(destinationURL)
@@ -421,7 +423,8 @@ struct HabitsWidgetEntryView: View {
         backgroundColor: backgroundColor,
         textPrimaryColor: primaryTextColor,
         inactiveRatio: inactiveRatio,
-        renderingMode: renderingMode
+        renderingMode: renderingMode,
+        visualizationStyle: entry.configuration.visualizationStyle.resolved()
       )
       .widgetURL(destinationURL)
     }
@@ -633,7 +636,8 @@ private func previewWidget(
     backgroundColor: backgroundColor,
     textPrimaryColor: primaryTextColor,
     inactiveRatio: WidgetStyle.futureDotFillRatio,
-    renderingMode: renderingMode
+    renderingMode: renderingMode,
+    visualizationStyle: .stored()
   )
   .frame(width: 360, height: 260)
   .padding()

--- a/SharedModels/Sources/SharedModels/CalendarWidgetIntent.swift
+++ b/SharedModels/Sources/SharedModels/CalendarWidgetIntent.swift
@@ -59,6 +59,9 @@ public struct CalendarWidgetConfigurationIntent: WidgetConfigurationIntent {
     )
     public var selectedCalendar: CalendarOption?
 
+    @Parameter(title: "Visualization", default: .appDefault)
+    public var visualizationStyle: WidgetGridStyleOption
+
     public init() {
         let calendars = CustomCalendarStore.fetchCalendarsSnapshot()
         if let calendar = calendars.first {

--- a/SharedModels/Sources/SharedModels/GridVisualizationStyle.swift
+++ b/SharedModels/Sources/SharedModels/GridVisualizationStyle.swift
@@ -1,3 +1,4 @@
+import AppIntents
 import Foundation
 import SwiftUI
 
@@ -112,6 +113,33 @@ public enum GridVisualizationStyle: String, CaseIterable, Identifiable, Sendable
             cornerSize: corner
         )
         return path
+    }
+}
+
+/// Per-widget choice of grid marks. `appDefault` follows the style selected in the app.
+public enum WidgetGridStyleOption: String, AppEnum, CaseIterable, Sendable {
+    case appDefault
+    case dot
+    case scaledDot
+    case sparkle
+    case cross
+
+    public static var typeDisplayRepresentation: TypeDisplayRepresentation { "Visualization" }
+    public static var caseDisplayRepresentations: [WidgetGridStyleOption: DisplayRepresentation] {
+        [
+            .appDefault: "App Setting",
+            .dot: "Dots",
+            .scaledDot: "Scaled Dots",
+            .sparkle: "Sparkles",
+            .cross: "Crosses"
+        ]
+    }
+
+    /// Raw values match GridVisualizationStyle, so the lookup is the mapping table.
+    public func resolved(
+        defaults: UserDefaults = TimelinePreferenceStore.appGroupDefaults
+    ) -> GridVisualizationStyle {
+        GridVisualizationStyle(rawValue: rawValue) ?? .stored(defaults: defaults)
     }
 }
 

--- a/SharedModels/Sources/SharedModels/WidgetPreviewDisplays.swift
+++ b/SharedModels/Sources/SharedModels/WidgetPreviewDisplays.swift
@@ -15,7 +15,7 @@ public struct YearProgressWidgetDisplayView: View {
     public let textPrimaryColor: Color
     public let inactiveRatio: Double
     public let renderingMode: WidgetStyle.RenderingMode
-    private let style = GridVisualizationStyle.stored()
+    public let style: GridVisualizationStyle
 
     private var dotSize: CGFloat {
         switch family {
@@ -34,7 +34,8 @@ public struct YearProgressWidgetDisplayView: View {
         backgroundColor: Color,
         textPrimaryColor: Color,
         inactiveRatio: Double = WidgetStyle.futureDotFillRatio,
-        renderingMode: WidgetStyle.RenderingMode = .fullColor
+        renderingMode: WidgetStyle.RenderingMode = .fullColor,
+        style: GridVisualizationStyle = .stored()
     ) {
         self.family = family
         self.referenceDate = referenceDate
@@ -42,6 +43,7 @@ public struct YearProgressWidgetDisplayView: View {
         self.textPrimaryColor = textPrimaryColor
         self.inactiveRatio = inactiveRatio
         self.renderingMode = renderingMode
+        self.style = style
     }
 
     public var body: some View {

--- a/SharedModels/Sources/SharedModels/YearWidgetIntent.swift
+++ b/SharedModels/Sources/SharedModels/YearWidgetIntent.swift
@@ -1,0 +1,17 @@
+import AppIntents
+import WidgetKit
+
+public struct YearWidgetConfigurationIntent: WidgetConfigurationIntent {
+    public static var title: LocalizedStringResource {
+        "Year Widget"
+    }
+
+    public static var description: IntentDescription {
+        "Show the year's progress."
+    }
+
+    @Parameter(title: "Visualization", default: .appDefault)
+    public var visualizationStyle: WidgetGridStyleOption
+
+    public init() {}
+}

--- a/YearWidget/YearWidget.swift
+++ b/YearWidget/YearWidget.swift
@@ -5,22 +5,23 @@ import WidgetKit
 
 struct SimpleEntry: TimelineEntry {
     let date: Date
+    let style: GridVisualizationStyle
 }
 
-struct Provider: TimelineProvider {
-    typealias Entry = SimpleEntry
-
+struct Provider: AppIntentTimelineProvider {
     func placeholder(in _: Context) -> SimpleEntry {
-        return SimpleEntry(date: Date())
+        makeEntry(for: YearWidgetConfigurationIntent(), date: Date())
     }
 
-    func getSnapshot(in _: Context, completion: @escaping (SimpleEntry) -> Void) {
-        let entry = SimpleEntry(date: Date())
-        completion(entry)
+    func snapshot(for configuration: YearWidgetConfigurationIntent, in _: Context) async -> SimpleEntry {
+        makeEntry(for: configuration, date: Date())
     }
 
-    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> Void) {
-        let entry = SimpleEntry(date: Date())
+    func timeline(
+        for configuration: YearWidgetConfigurationIntent,
+        in context: Context
+    ) async -> Timeline<SimpleEntry> {
+        let entry = makeEntry(for: configuration, date: Date())
 
         if !context.isPreview {
             WidgetAnalyticsQueue.shared.enqueueTimelineLoaded(properties: [
@@ -35,8 +36,11 @@ struct Provider: TimelineProvider {
         let calendar = Calendar.current
         let tomorrow = calendar.startOfDay(for: calendar.date(byAdding: .day, value: 1, to: Date()) ?? Date())
 
-        let timeline = Timeline(entries: [entry], policy: .after(tomorrow))
-        completion(timeline)
+        return Timeline(entries: [entry], policy: .after(tomorrow))
+    }
+
+    private func makeEntry(for configuration: YearWidgetConfigurationIntent, date: Date) -> SimpleEntry {
+        SimpleEntry(date: date, style: configuration.visualizationStyle.resolved())
     }
 }
 
@@ -67,7 +71,8 @@ struct YearWidgetEntryView: View {
             backgroundColor: backgroundColor,
             textPrimaryColor: primaryTextColor,
             inactiveRatio: inactiveRatio,
-            renderingMode: renderingMode
+            renderingMode: renderingMode,
+            style: entry.style
         )
         .containerBackground(backgroundColor, for: .widget)
         .widgetAccentable(false)
@@ -92,7 +97,11 @@ struct YearWidget: Widget {
     let kind: String = WidgetKinds.year
 
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+        AppIntentConfiguration(
+            kind: kind,
+            intent: YearWidgetConfigurationIntent.self,
+            provider: Provider()
+        ) { entry in
             YearWidgetEntryView(entry: entry)
         }
         .configurationDisplayName("Year Progress")


### PR DESCRIPTION
Each home-screen grid widget now has a Visualization option in its configuration sheet. The default, App Setting, follows the style selected in the app, so installed widgets keep their current look. The lock screen Recent Weeks widget always uses scaled dots.

## What changed

- `WidgetGridStyleOption` is a new AppEnum in SharedModels. Its raw values match `GridVisualizationStyle`, so resolving it is a lookup with a fallback to the stored app setting.
- `CalendarWidgetConfigurationIntent` gained the `visualizationStyle` parameter. The type name is unchanged, so installed Habits and Streak widgets keep their configuration.
- New `YearWidgetConfigurationIntent` with the same parameter. The Year widget moved from `StaticConfiguration` to `AppIntentConfiguration`.
- `HorizontalCalendarGrid` and `YearProgressWidgetDisplayView` take the style as an init parameter instead of reading the app-group defaults inside the view.
- `HabitWeeksWidget` passes `.scaledDot` and no longer reads the stored style.

## Known trade-off

The Streak widget shares the intent with the Habits widget, so its configuration sheet also shows the Visualization option. The Streak widget has no grid and ignores it. Splitting the intents would reset installed widgets, so I kept the shared type. Open to a follow-up if the inert option bothers testers.

## Verification

- `xcodebuild` for the "My Year" scheme: BUILD SUCCEEDED.
- SwiftLint: no new warnings in the changed files.
- Not verified on the simulator home screen. Please edit a Year widget and a Habits widget and switch the Visualization option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
