### PR TITLE
feat: densify the Recent Weeks lock screen grid

### DIFF
--- a/HabitsWidget/HabitWeeksWidget.swift
+++ b/HabitsWidget/HabitWeeksWidget.swift
@@ -9,8 +9,8 @@ import SharedModels
 import SwiftUI
 import WidgetKit
 
-private let weekRows = 3
-private let daysPerWeek = 7
+private let daysPerRow = 14
+private let gapRatio: CGFloat = 0.4
 
 struct HabitWeeksWidgetEntryView: View {
   var entry: SimpleEntry
@@ -32,7 +32,7 @@ struct HabitWeeksWidgetEntryView: View {
       renderingMode: renderingMode
     )
 
-    VStack(alignment: .leading, spacing: 2) {
+    VStack(alignment: .leading, spacing: 6) {
       if let calendar = entry.calendar {
         Text(calendar.name)
           .font(AppFont.mono(11))
@@ -64,29 +64,28 @@ private struct HabitWeeksDotGrid: View {
 
   var body: some View {
     GeometryReader { geometry in
-      let columns = CGFloat(daysPerWeek)
-      let rows = CGFloat(weekRows)
-      let dotSize = min(geometry.size.height / rows, geometry.size.width / columns) * 0.62
-      let horizontalSpacing = max(1, (geometry.size.width - dotSize * columns) / (columns - 1))
-      let verticalSpacing = max(1, (geometry.size.height - dotSize * rows) / (rows - 1))
+      let columns = CGFloat(daysPerRow)
+      let dotSize = geometry.size.width / (columns + ((columns - 1) * gapRatio))
+      let horizontalSpacing = dotSize * gapRatio
+      let rowsThatFit = Int((geometry.size.height + horizontalSpacing) / (dotSize + horizontalSpacing))
+      let rows = min(days.count / daysPerRow, rowsThatFit)
+      let verticalSpacing = rows > 1
+        ? (geometry.size.height - (dotSize * CGFloat(rows))) / CGFloat(rows - 1)
+        : 0
+      let shown = Array(days.suffix(rows * daysPerRow))
 
       VStack(spacing: verticalSpacing) {
-        ForEach(0..<weekRows, id: \.self) { row in
+        ForEach(0..<rows, id: \.self) { row in
           HStack(spacing: horizontalSpacing) {
-            ForEach(0..<daysPerWeek, id: \.self) { col in
-              let index = (row * daysPerWeek) + col
-              if index < days.count {
-                let gridDay = days[index]
-                WidgetGridDot(
-                  color: gridDay.color,
-                  dotSize: dotSize,
-                  accentable: gridDay.accentable,
-                  style: style,
-                  fillRatio: gridDay.fillRatio
-                )
-              } else {
-                Color.clear.frame(width: dotSize, height: dotSize)
-              }
+            ForEach(0..<daysPerRow, id: \.self) { col in
+              let gridDay = shown[(row * daysPerRow) + col]
+              WidgetGridDot(
+                color: gridDay.color,
+                dotSize: dotSize,
+                accentable: gridDay.accentable,
+                style: style,
+                fillRatio: gridDay.fillRatio
+              )
             }
           }
         }

--- a/HabitsWidget/HabitWidgetGridSnapshot.swift
+++ b/HabitsWidget/HabitWidgetGridSnapshot.swift
@@ -254,14 +254,14 @@ private struct HabitWidgetGridSnapshotBuilder {
     return family == .systemSmall ? recentDates(from: today, days: 35) : yearDates(containing: today)
   }
 
-  /// Whole weeks aligned to the week start, so the Lock Screen rows read as a calendar.
+  /// Twelve whole weeks aligned to the week start; the Lock Screen view shows as many rows as fit.
   private func accessoryDates(today: Date) -> [Date] {
     if let calendar, calendar.cadence == .weekly {
-      return recentWeeks(from: today, weeks: 21)
+      return recentWeeks(from: today, weeks: 84)
     }
     let dayCalendar = LocalDayCalendar.calendar
     let weekStart = LocalDayCalendar.startOfWeek(for: today)
-    guard let start = dayCalendar.date(byAdding: .weekOfYear, value: -2, to: weekStart),
+    guard let start = dayCalendar.date(byAdding: .weekOfYear, value: -11, to: weekStart),
       let end = dayCalendar.date(byAdding: .day, value: 6, to: weekStart)
     else {
       return []


### PR DESCRIPTION
The Recent Weeks Lock Screen widget shows a denser grid with more breathing room under the habit name.

- Rows hold two weeks (14 days). The row count is computed from the height available, so a small phone shows six weeks in three rows and a large phone eight weeks in four rows.
- Gaps are uniform at 0.4 of a dot. The dot size comes from the width.
- The gap between the habit name and the grid grows from 2 to 6 points.
- `accessoryDates` supplies twelve weeks (84 days, or 84 week starts for weekly habits) so the view can pick as many recent rows as fit.

Prototyped as rendered images at 160×68 and 172×76 before coding. Independent of #154; both touch `HabitWeeksWidget.swift` on different lines.

Verification: `xcodebuild` BUILD SUCCEEDED, SwiftLint clean on the new file. Not verified on a real Lock Screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
